### PR TITLE
Consider `extends`

### DIFF
--- a/bin/generate_files
+++ b/bin/generate_files
@@ -2,4 +2,4 @@
 
 set -ex
 yarn install
-yarn run -s ts-node scripts/generateFiles.ts
+yarn run -s -- ts-node --compilerOptions '{"target":"es6"}' scripts/generateFiles.ts

--- a/lib/language_server/protocol/interface/code_lens_registration_options.rb
+++ b/lib/language_server/protocol/interface/code_lens_registration_options.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class CodeLensRegistrationOptions
-        def initialize(resolve_provider: nil)
+      class CodeLensRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, resolve_provider: nil)
           @attributes = {}
 
           @attributes[:resolveProvider] = resolve_provider if resolve_provider

--- a/lib/language_server/protocol/interface/completion_registration_options.rb
+++ b/lib/language_server/protocol/interface/completion_registration_options.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class CompletionRegistrationOptions
-        def initialize(trigger_characters: nil, resolve_provider: nil)
+      class CompletionRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, trigger_characters: nil, resolve_provider: nil)
           @attributes = {}
 
           @attributes[:triggerCharacters] = trigger_characters if trigger_characters

--- a/lib/language_server/protocol/interface/document_link_registration_options.rb
+++ b/lib/language_server/protocol/interface/document_link_registration_options.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class DocumentLinkRegistrationOptions
-        def initialize(resolve_provider: nil)
+      class DocumentLinkRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, resolve_provider: nil)
           @attributes = {}
 
           @attributes[:resolveProvider] = resolve_provider if resolve_provider

--- a/lib/language_server/protocol/interface/document_on_type_formatting_registration_options.rb
+++ b/lib/language_server/protocol/interface/document_on_type_formatting_registration_options.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class DocumentOnTypeFormattingRegistrationOptions
-        def initialize(first_trigger_character:, more_trigger_character: nil)
+      class DocumentOnTypeFormattingRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, first_trigger_character:, more_trigger_character: nil)
           @attributes = {}
 
           @attributes[:firstTriggerCharacter] = first_trigger_character

--- a/lib/language_server/protocol/interface/notification_message.rb
+++ b/lib/language_server/protocol/interface/notification_message.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class NotificationMessage
-        def initialize(method:, params: nil)
+      class NotificationMessage < Message
+        def initialize(jsonrpc:, method:, params: nil)
           @attributes = {}
 
           @attributes[:method] = method

--- a/lib/language_server/protocol/interface/reference_params.rb
+++ b/lib/language_server/protocol/interface/reference_params.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class ReferenceParams
-        def initialize(context:)
+      class ReferenceParams < TextDocumentPositionParams
+        def initialize(text_document:, position:, context:)
           @attributes = {}
 
           @attributes[:context] = context

--- a/lib/language_server/protocol/interface/request_message.rb
+++ b/lib/language_server/protocol/interface/request_message.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class RequestMessage
-        def initialize(id:, method:, params: nil)
+      class RequestMessage < Message
+        def initialize(jsonrpc:, id:, method:, params: nil)
           @attributes = {}
 
           @attributes[:id] = id

--- a/lib/language_server/protocol/interface/response_message.rb
+++ b/lib/language_server/protocol/interface/response_message.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class ResponseMessage
-        def initialize(id:, result: nil, error: nil)
+      class ResponseMessage < Message
+        def initialize(jsonrpc:, id:, result: nil, error: nil)
           @attributes = {}
 
           @attributes[:id] = id

--- a/lib/language_server/protocol/interface/signature_help_registration_options.rb
+++ b/lib/language_server/protocol/interface/signature_help_registration_options.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class SignatureHelpRegistrationOptions
-        def initialize(trigger_characters: nil)
+      class SignatureHelpRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, trigger_characters: nil)
           @attributes = {}
 
           @attributes[:triggerCharacters] = trigger_characters if trigger_characters

--- a/lib/language_server/protocol/interface/text_document_change_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_change_registration_options.rb
@@ -4,8 +4,8 @@ module LanguageServer
       #
       # Descibe options to be used when registered for text document change events.
       #
-      class TextDocumentChangeRegistrationOptions
-        def initialize(sync_kind:)
+      class TextDocumentChangeRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, sync_kind:)
           @attributes = {}
 
           @attributes[:syncKind] = sync_kind

--- a/lib/language_server/protocol/interface/text_document_save_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_save_registration_options.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class TextDocumentSaveRegistrationOptions
-        def initialize(include_text: nil)
+      class TextDocumentSaveRegistrationOptions < TextDocumentRegistrationOptions
+        def initialize(document_selector:, include_text: nil)
           @attributes = {}
 
           @attributes[:includeText] = include_text if include_text

--- a/lib/language_server/protocol/interface/versioned_text_document_identifier.rb
+++ b/lib/language_server/protocol/interface/versioned_text_document_identifier.rb
@@ -1,8 +1,8 @@
 module LanguageServer
   module Protocol
     module Interface
-      class VersionedTextDocumentIdentifier
-        def initialize(version:)
+      class VersionedTextDocumentIdentifier < TextDocumentIdentifier
+        def initialize(uri:, version:)
           @attributes = {}
 
           @attributes[:version] = version

--- a/scripts/generateFiles.ts
+++ b/scripts/generateFiles.ts
@@ -59,10 +59,14 @@ const extractDefinitions = content => {
 
   const handleInterface = (node: ts.InterfaceDeclaration) => {
     const members = node.members.filter(member => member.name).map(member => serialize(member));
+    const parentName = node.heritageClauses && node.heritageClauses[0].getLastToken().getText();
+    const parent = output.find(i => i.interface && (i.interface.name === parentName));
 
     output.push(
     {
       interface: serialize(node),
+      parent: parent,
+      allMembers: ((parent && parent.allMembers) || []).concat(members),
       members
     }
     );
@@ -148,8 +152,8 @@ module LanguageServer
 {{comment definition.interface.documentation indent=6}}
       #
       {{/if}}
-      class {{definition.interface.name}}
-        def initialize({{params definition.members}})
+      class {{definition.interface.name}}{{#if definition.parent}} < {{definition.parent.interface.name}}{{/if}}
+        def initialize({{params definition.allMembers}})
           @attributes = {}
 
           {{#each definition.members}}


### PR DESCRIPTION
As [@alpaca-tc mentioned](https://github.com/mtsmfm/language_server-protocol-ruby/pull/4#issuecomment-331949814), I forgot to consider `extends`.