### PR TITLE
Add to_hash to keep compatibility with Rails

### DIFF
--- a/language_server-protocol.gemspec
+++ b/language_server-protocol.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "minitest-power_assert"
   spec.add_development_dependency "m"
+  spec.add_development_dependency "activesupport"
 end

--- a/lib/language_server/protocol/interface/apply_workspace_edit_params.rb
+++ b/lib/language_server/protocol/interface/apply_workspace_edit_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/apply_workspace_edit_response.rb
+++ b/lib/language_server/protocol/interface/apply_workspace_edit_response.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/cancel_params.rb
+++ b/lib/language_server/protocol/interface/cancel_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/client_capabilities.rb
+++ b/lib/language_server/protocol/interface/client_capabilities.rb
@@ -38,8 +38,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/code_action_context.rb
+++ b/lib/language_server/protocol/interface/code_action_context.rb
@@ -24,8 +24,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/code_action_params.rb
+++ b/lib/language_server/protocol/interface/code_action_params.rb
@@ -41,8 +41,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/code_lens.rb
+++ b/lib/language_server/protocol/interface/code_lens.rb
@@ -46,8 +46,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/code_lens_options.rb
+++ b/lib/language_server/protocol/interface/code_lens_options.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/code_lens_params.rb
+++ b/lib/language_server/protocol/interface/code_lens_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/code_lens_registration_options.rb
+++ b/lib/language_server/protocol/interface/code_lens_registration_options.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/command.rb
+++ b/lib/language_server/protocol/interface/command.rb
@@ -39,8 +39,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/completion_item.rb
+++ b/lib/language_server/protocol/interface/completion_item.rb
@@ -136,8 +136,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/completion_list.rb
+++ b/lib/language_server/protocol/interface/completion_list.rb
@@ -34,8 +34,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/completion_options.rb
+++ b/lib/language_server/protocol/interface/completion_options.rb
@@ -33,8 +33,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/completion_registration_options.rb
+++ b/lib/language_server/protocol/interface/completion_registration_options.rb
@@ -30,8 +30,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/diagnostic.rb
+++ b/lib/language_server/protocol/interface/diagnostic.rb
@@ -58,8 +58,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/did_change_configuration_params.rb
+++ b/lib/language_server/protocol/interface/did_change_configuration_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/did_change_text_document_params.rb
+++ b/lib/language_server/protocol/interface/did_change_text_document_params.rb
@@ -31,8 +31,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/did_change_watched_files_params.rb
+++ b/lib/language_server/protocol/interface/did_change_watched_files_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/did_close_text_document_params.rb
+++ b/lib/language_server/protocol/interface/did_close_text_document_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/did_open_text_document_params.rb
+++ b/lib/language_server/protocol/interface/did_open_text_document_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/did_save_text_document_params.rb
+++ b/lib/language_server/protocol/interface/did_save_text_document_params.rb
@@ -30,8 +30,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_filter.rb
+++ b/lib/language_server/protocol/interface/document_filter.rb
@@ -38,8 +38,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_formatting_params.rb
+++ b/lib/language_server/protocol/interface/document_formatting_params.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_highlight.rb
+++ b/lib/language_server/protocol/interface/document_highlight.rb
@@ -34,8 +34,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_link.rb
+++ b/lib/language_server/protocol/interface/document_link.rb
@@ -33,8 +33,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_link_options.rb
+++ b/lib/language_server/protocol/interface/document_link_options.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_link_params.rb
+++ b/lib/language_server/protocol/interface/document_link_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_link_registration_options.rb
+++ b/lib/language_server/protocol/interface/document_link_registration_options.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_on_type_formatting_options.rb
+++ b/lib/language_server/protocol/interface/document_on_type_formatting_options.rb
@@ -32,8 +32,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_on_type_formatting_params.rb
+++ b/lib/language_server/protocol/interface/document_on_type_formatting_params.rb
@@ -47,8 +47,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_on_type_formatting_registration_options.rb
+++ b/lib/language_server/protocol/interface/document_on_type_formatting_registration_options.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_range_formatting_params.rb
+++ b/lib/language_server/protocol/interface/document_range_formatting_params.rb
@@ -38,8 +38,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/document_symbol_params.rb
+++ b/lib/language_server/protocol/interface/document_symbol_params.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/execute_command_options.rb
+++ b/lib/language_server/protocol/interface/execute_command_options.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/execute_command_params.rb
+++ b/lib/language_server/protocol/interface/execute_command_params.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/execute_command_registration_options.rb
+++ b/lib/language_server/protocol/interface/execute_command_registration_options.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/file_event.rb
+++ b/lib/language_server/protocol/interface/file_event.rb
@@ -32,8 +32,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/formatting_options.rb
+++ b/lib/language_server/protocol/interface/formatting_options.rb
@@ -32,8 +32,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/hover.rb
+++ b/lib/language_server/protocol/interface/hover.rb
@@ -33,8 +33,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/initialize_error.rb
+++ b/lib/language_server/protocol/interface/initialize_error.rb
@@ -26,8 +26,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/initialize_params.rb
+++ b/lib/language_server/protocol/interface/initialize_params.rb
@@ -70,8 +70,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/initialize_result.rb
+++ b/lib/language_server/protocol/interface/initialize_result.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/location.rb
+++ b/lib/language_server/protocol/interface/location.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/log_message_params.rb
+++ b/lib/language_server/protocol/interface/log_message_params.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/message.rb
+++ b/lib/language_server/protocol/interface/message.rb
@@ -17,8 +17,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/message_action_item.rb
+++ b/lib/language_server/protocol/interface/message_action_item.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/notification_message.rb
+++ b/lib/language_server/protocol/interface/notification_message.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/parameter_information.rb
+++ b/lib/language_server/protocol/interface/parameter_information.rb
@@ -35,8 +35,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/position.rb
+++ b/lib/language_server/protocol/interface/position.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/publish_diagnostics_params.rb
+++ b/lib/language_server/protocol/interface/publish_diagnostics_params.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/range.rb
+++ b/lib/language_server/protocol/interface/range.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/reference_context.rb
+++ b/lib/language_server/protocol/interface/reference_context.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/reference_params.rb
+++ b/lib/language_server/protocol/interface/reference_params.rb
@@ -17,8 +17,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/registration.rb
+++ b/lib/language_server/protocol/interface/registration.rb
@@ -42,8 +42,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/registration_params.rb
+++ b/lib/language_server/protocol/interface/registration_params.rb
@@ -17,8 +17,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/rename_params.rb
+++ b/lib/language_server/protocol/interface/rename_params.rb
@@ -40,8 +40,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/request_message.rb
+++ b/lib/language_server/protocol/interface/request_message.rb
@@ -38,8 +38,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/response_error.rb
+++ b/lib/language_server/protocol/interface/response_error.rb
@@ -39,8 +39,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/response_message.rb
+++ b/lib/language_server/protocol/interface/response_message.rb
@@ -39,8 +39,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/save_options.rb
+++ b/lib/language_server/protocol/interface/save_options.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/server_capabilities.rb
+++ b/lib/language_server/protocol/interface/server_capabilities.rb
@@ -174,8 +174,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/show_message_params.rb
+++ b/lib/language_server/protocol/interface/show_message_params.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/show_message_request_params.rb
+++ b/lib/language_server/protocol/interface/show_message_request_params.rb
@@ -38,8 +38,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/signature_help.rb
+++ b/lib/language_server/protocol/interface/signature_help.rb
@@ -55,8 +55,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/signature_help_options.rb
+++ b/lib/language_server/protocol/interface/signature_help_options.rb
@@ -24,8 +24,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/signature_help_registration_options.rb
+++ b/lib/language_server/protocol/interface/signature_help_registration_options.rb
@@ -21,8 +21,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/signature_information.rb
+++ b/lib/language_server/protocol/interface/signature_information.rb
@@ -45,8 +45,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/symbol_information.rb
+++ b/lib/language_server/protocol/interface/symbol_information.rb
@@ -51,8 +51,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_change_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_change_registration_options.rb
@@ -24,8 +24,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_client_capabilities.rb
+++ b/lib/language_server/protocol/interface/text_document_client_capabilities.rb
@@ -146,8 +146,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_content_change_event.rb
+++ b/lib/language_server/protocol/interface/text_document_content_change_event.rb
@@ -42,8 +42,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_edit.rb
+++ b/lib/language_server/protocol/interface/text_document_edit.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_identifier.rb
+++ b/lib/language_server/protocol/interface/text_document_identifier.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_item.rb
+++ b/lib/language_server/protocol/interface/text_document_item.rb
@@ -48,8 +48,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_position_params.rb
+++ b/lib/language_server/protocol/interface/text_document_position_params.rb
@@ -29,8 +29,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_registration_options.rb
@@ -21,8 +21,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_save_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_save_registration_options.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_document_sync_options.rb
+++ b/lib/language_server/protocol/interface/text_document_sync_options.rb
@@ -57,8 +57,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/text_edit.rb
+++ b/lib/language_server/protocol/interface/text_edit.rb
@@ -31,8 +31,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/unregistration.rb
+++ b/lib/language_server/protocol/interface/unregistration.rb
@@ -33,8 +33,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/unregistration_params.rb
+++ b/lib/language_server/protocol/interface/unregistration_params.rb
@@ -17,8 +17,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/versioned_text_document_identifier.rb
+++ b/lib/language_server/protocol/interface/versioned_text_document_identifier.rb
@@ -20,8 +20,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/will_save_text_document_params.rb
+++ b/lib/language_server/protocol/interface/will_save_text_document_params.rb
@@ -32,8 +32,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/workspace_client_capabilites.rb
+++ b/lib/language_server/protocol/interface/workspace_client_capabilites.rb
@@ -69,8 +69,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/workspace_edit.rb
+++ b/lib/language_server/protocol/interface/workspace_edit.rb
@@ -31,8 +31,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/lib/language_server/protocol/interface/workspace_symbol_params.rb
+++ b/lib/language_server/protocol/interface/workspace_symbol_params.rb
@@ -23,8 +23,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/scripts/generateFiles.ts
+++ b/scripts/generateFiles.ts
@@ -177,8 +177,12 @@ module LanguageServer
 
         attr_reader :attributes
 
+        def to_hash
+          attributes
+        end
+
         def to_json(*args)
-          attributes.to_json(*args)
+          to_hash.to_json(*args)
         end
       end
     end

--- a/test/language_server/protocol_test.rb
+++ b/test/language_server/protocol_test.rb
@@ -1,22 +1,28 @@
 require "test_helper"
 require "open3"
+require 'active_support/all'
 
 class LanguageServer::ProtocolTest < Minitest::Test
-  def test_initialize_call
-    stdin, stdout, stderr, wait_thr = *Open3.popen3("bundle exec ruby test/example.rb")
+  [
+    "ruby -r bundler/setup test/example.rb",
+    "ruby -r bundler/setup -r active_support/all test/example.rb"
+  ].each do |command|
+    define_method "test_initialize_with_`#{command}`" do
+      stdin, stdout, stderr, wait_thr = Open3.popen3(command)
 
-    stdin.print to_jsonrpc(jsonrpc: 2.0, id: 0, method: :initialize, params: {processId: 1234})
+      stdin.print to_jsonrpc(jsonrpc: 2.0, id: 0, method: :initialize, params: {processId: 1234})
 
-    sleep 1 unless wait_thr.stop?
+      sleep 1 unless wait_thr.stop?
 
-    expected_body = {
-      "id"=>0,
-      "result"=>{"capabilities"=>{"textDocumentSync"=>{"change"=>1}, "completionProvider"=>{"resolveProvider"=>true, "triggerCharacters"=>["."]}, "definitionProvider"=>true}},
-      "jsonrpc"=>"2.0"
-    }
+      expected_body = {
+        "id"=>0,
+        "result"=>{"capabilities"=>{"textDocumentSync"=>{"change"=>1}, "completionProvider"=>{"resolveProvider"=>true, "triggerCharacters"=>["."]}, "definitionProvider"=>true}},
+        "jsonrpc"=>"2.0"
+      }
 
-    assert { stdout.read == to_jsonrpc(expected_body) }
-    assert { stderr.read == "" }
+      assert { stdout.read == to_jsonrpc(expected_body) }
+      assert { stderr.read == "" }
+    end
   end
 
   def to_jsonrpc(hash)


### PR DESCRIPTION
ref: https://github.com/mtsmfm/language_server-protocol-ruby/issues/8

To use with Rails, I think we have three options:

1. Use `JSON.dump` instead of `to_json` as @rmosolgo suggested  (https://github.com/mtsmfm/language_server-protocol-ruby/issues/8)
2. Add `as_json` method
3. Add `to_hash` method

I think option 3 is the best because actually these interfaces always act as Hash.

@rmosolgo Could you tell me your opinion? 🙏 