### PR TITLE
Add completion kinds such as CONSTANT newly added to LSP specification

### DIFF
--- a/lib/language_server/protocol/constant/completion_item_kind.rb
+++ b/lib/language_server/protocol/constant/completion_item_kind.rb
@@ -23,6 +23,13 @@ module LanguageServer
         COLOR = 16
         FILE = 17
         REFERENCE = 18
+        FOLDER = 19
+        ENUM_MEMBER = 20
+        CONSTANT = 21
+        STRUCT = 22
+        EVENT = 23
+        OPERATOR = 24
+        TYPE_PARAMETER = 25
       end
     end
   end


### PR DESCRIPTION
This PR adds definitions of newly added CompletionItemKind items.

```ts
namespace CompletionItemKind {
        ...
	export const Folder = 19;
	export const EnumMember = 20;
	export const Constant = 21;
	export const Struct = 22;
	export const Event = 23;
	export const Operator = 24;
	export const TypeParameter = 25;
}
```
(https://microsoft.github.io/language-server-protocol/specification#textDocument_completion)

These kinds are added to Microsoft LSP implementation on Nov 2017.
https://github.com/Microsoft/vscode-languageserver-node/pull/280

(There are no way to know post versions of LSP specification, so we cannot know which version these kinds are added to LSP specification, although I think it would be [v3.4.0](https://microsoft.github.io/language-server-protocol/specification#version_3_4_0))