### PR TITLE
Reduce gem package size

### DIFF
--- a/language_server-protocol.gemspec
+++ b/language_server-protocol.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/mtsmfm/language_server-protocol-ruby"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = `git ls-files -z lib LICENSE.txt README.md`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This pull request will reduce the gem package size by removing some files from the package.

I think removing `yarn.lock` will mostly reduce the size, because `yarn.lock` is 9.9KB.


I've confirmed this change reduced about 10KB, it is 20%.

```bash
# before this pull request
$ gem build language_server-protocol.gemspec
$ wc -c language_server-protocol-3.14.0.1.gem # it prints byte size.
45568 language_server-protocol-3.14.0.1.gem

# after this pull request
$ gem build language_server-protocol.gemspec
$ wc -c language_server-protocol-3.14.0.1.gem
35840 language_server-protocol-3.14.0.1.gem
```




But, I understand it will be a small impact in the real world. We have a high-speed network, so the 10KB difference can be ignored.
So if you think this change is not reasonable, feel free to close it.


---

By the way, this change is based on rubocop's gemspec.
https://github.com/rubocop-hq/rubocop/blob/ebae59be1d9e05bec311ce63b62b182f7a5cd118/rubocop.gemspec#L19-L20