### PR TITLE
Fix inheritance code generation

### DIFF
--- a/lib/language_server/protocol/interface/code_action_registration_options.rb
+++ b/lib/language_server/protocol/interface/code_action_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(code_action_kinds: nil)
           @attributes = {}
 
+          @attributes[:codeActionKinds] = code_action_kinds if code_action_kinds
 
           @attributes.freeze
         end

--- a/lib/language_server/protocol/interface/code_lens_registration_options.rb
+++ b/lib/language_server/protocol/interface/code_lens_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, resolve_provider: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:resolveProvider] = resolve_provider if resolve_provider
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/completion_params.rb
+++ b/lib/language_server/protocol/interface/completion_params.rb
@@ -5,6 +5,8 @@ module LanguageServer
         def initialize(text_document:, position:, context: nil)
           @attributes = {}
 
+          @attributes[:textDocument] = text_document
+          @attributes[:position] = position
           @attributes[:context] = context if context
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/completion_registration_options.rb
+++ b/lib/language_server/protocol/interface/completion_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, trigger_characters: nil, resolve_provider: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:triggerCharacters] = trigger_characters if trigger_characters
           @attributes[:resolveProvider] = resolve_provider if resolve_provider
 

--- a/lib/language_server/protocol/interface/document_link_registration_options.rb
+++ b/lib/language_server/protocol/interface/document_link_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, resolve_provider: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:resolveProvider] = resolve_provider if resolve_provider
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/document_on_type_formatting_registration_options.rb
+++ b/lib/language_server/protocol/interface/document_on_type_formatting_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, first_trigger_character:, more_trigger_character: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:firstTriggerCharacter] = first_trigger_character
           @attributes[:moreTriggerCharacter] = more_trigger_character if more_trigger_character
 

--- a/lib/language_server/protocol/interface/notification_message.rb
+++ b/lib/language_server/protocol/interface/notification_message.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(jsonrpc:, method:, params: nil)
           @attributes = {}
 
+          @attributes[:jsonrpc] = jsonrpc
           @attributes[:method] = method
           @attributes[:params] = params if params
 

--- a/lib/language_server/protocol/interface/reference_params.rb
+++ b/lib/language_server/protocol/interface/reference_params.rb
@@ -5,6 +5,8 @@ module LanguageServer
         def initialize(text_document:, position:, context:)
           @attributes = {}
 
+          @attributes[:textDocument] = text_document
+          @attributes[:position] = position
           @attributes[:context] = context
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/rename_registration_options.rb
+++ b/lib/language_server/protocol/interface/rename_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, prepare_provider: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:prepareProvider] = prepare_provider if prepare_provider
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/request_message.rb
+++ b/lib/language_server/protocol/interface/request_message.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(jsonrpc:, id:, method:, params: nil)
           @attributes = {}
 
+          @attributes[:jsonrpc] = jsonrpc
           @attributes[:id] = id
           @attributes[:method] = method
           @attributes[:params] = params if params

--- a/lib/language_server/protocol/interface/response_message.rb
+++ b/lib/language_server/protocol/interface/response_message.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(jsonrpc:, id:, result: nil, error: nil)
           @attributes = {}
 
+          @attributes[:jsonrpc] = jsonrpc
           @attributes[:id] = id
           @attributes[:result] = result if result
           @attributes[:error] = error if error

--- a/lib/language_server/protocol/interface/signature_help_registration_options.rb
+++ b/lib/language_server/protocol/interface/signature_help_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, trigger_characters: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:triggerCharacters] = trigger_characters if trigger_characters
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/text_document_change_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_change_registration_options.rb
@@ -8,6 +8,7 @@ module LanguageServer
         def initialize(document_selector:, sync_kind:)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:syncKind] = sync_kind
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/text_document_save_registration_options.rb
+++ b/lib/language_server/protocol/interface/text_document_save_registration_options.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(document_selector:, include_text: nil)
           @attributes = {}
 
+          @attributes[:documentSelector] = document_selector
           @attributes[:includeText] = include_text if include_text
 
           @attributes.freeze

--- a/lib/language_server/protocol/interface/versioned_text_document_identifier.rb
+++ b/lib/language_server/protocol/interface/versioned_text_document_identifier.rb
@@ -5,6 +5,7 @@ module LanguageServer
         def initialize(uri:, version:)
           @attributes = {}
 
+          @attributes[:uri] = uri
           @attributes[:version] = version
 
           @attributes.freeze

--- a/scripts/generateFiles.ts
+++ b/scripts/generateFiles.ts
@@ -197,7 +197,7 @@ module LanguageServer
         def initialize({{params definition.allMembers}})
           @attributes = {}
 
-          {{#each definition.members}}
+          {{#each definition.allMembers}}
           @attributes[:{{name}}] = {{local_var name}}{{#if optional}} if {{local_var name}}{{/if}}
           {{/each}}
 

--- a/test/language_server/protocol_test.rb
+++ b/test/language_server/protocol_test.rb
@@ -73,4 +73,13 @@ class LanguageServer::ProtocolTest < Minitest::Test
 
     "Content-Length: #{hash_str.bytesize}\r\n" + "\r\n" + hash_str
   end
+
+  def test_sub_interface_set_super_attributes
+    identifier = LSP::Interface::VersionedTextDocumentIdentifier.new(
+      uri: "http://example.com",
+      version: 1
+    )
+
+    assert { identifier.attributes == { uri: "http://example.com", version: 1 } }
+  end
 end


### PR DESCRIPTION
This PR is to let interface classes with inheritance handle parameters correctly.

`VersionedTextDocumentIdentifier` would explain the problem:

```rb
      class VersionedTextDocumentIdentifier < TextDocumentIdentifier
        def initialize(uri:, version:)
          @attributes = {}

          @attributes[:version] = version       # uri is ignored! 🗑️ 

          @attributes.freeze
        end
    ...
```

The new generate code set up the parents' attributes: call `super`, `dup` the `@attributes`, and finally set the attributes of the children.