### PR TITLE
Frozen string

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ references:
           name: test
           command: |
             docker-compose run $CIRCLE_JOB bundle exec rake test
+            docker-compose run $CIRCLE_JOB RUBYOPT="--enable-frozen-string-literal" bundle exec rake test
 
 jobs:
   ruby-2-6:

--- a/lib/language_server/protocol/transport/io/reader.rb
+++ b/lib/language_server/protocol/transport/io/reader.rb
@@ -10,7 +10,7 @@ module LanguageServer
           end
 
           def read(&block)
-            buffer = ""
+            buffer = +""
             header_parsed = false
             content_length = nil
 


### PR DESCRIPTION
I found that `Reader` doesn't work with `--enable-frozen-string-literal` environment. This PR is to add `+` to ensure the value of `buffer` is not frozen.