### PR TITLE
Support for windows

### DIFF
--- a/lib/language_server/protocol/transport/io/reader.rb
+++ b/lib/language_server/protocol/transport/io/reader.rb
@@ -7,6 +7,7 @@ module LanguageServer
         class Reader
           def initialize(io)
             @io = io
+            io.binmode
           end
 
           def read(&block)

--- a/lib/language_server/protocol/transport/io/writer.rb
+++ b/lib/language_server/protocol/transport/io/writer.rb
@@ -7,6 +7,7 @@ module LanguageServer
 
           def initialize(io)
             @io = io
+            io.binmode
           end
 
           def write(response)

--- a/test/language_server/protocol_test.rb
+++ b/test/language_server/protocol_test.rb
@@ -11,6 +11,7 @@ class LanguageServer::ProtocolTest < Minitest::Test
   ].each do |command|
     define_method "test_initialize_with_`#{command}`" do
       stdin, stdout, stderr, wait_thr = Open3.popen3(command)
+      stdout.binmode
 
       stdin.print to_jsonrpc(jsonrpc: 2.0, id: 0, method: :initialize, params: {processId: 1234})
 


### PR DESCRIPTION
Current main baseline does not work for windows.
I added IO#binmode into reader.rb, writer.rb, and a one of test.
