### PR TITLE
[Docs] Fix a broken link for CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the LanguageServer::Protocol project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/mtsmfm/language_server-protocol/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the LanguageServer::Protocol project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/mtsmfm/language_server-protocol-ruby/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This PR fixes a broken link for Code of Conduct.