### PR TITLE
Add simple RBS signatures for generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 /node_modules
 /vendor
+/.gem_rbs_collection/

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gemspec
 gem "benchmark-ips"
 gem "pry-byebug"
 gem "activesupport"
-gem "steep"
+gem "steep", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gemspec
 gem "benchmark-ips"
 gem "pry-byebug"
 gem "activesupport"
+gem "steep"

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,17 @@
+D = Steep::Diagnostic
+
+target :lib do
+  signature "sig"
+
+  check "lib"                       # Directory name
+
+  # configure_code_diagnostics(D::Ruby.default)      # `default` diagnostics setting (applies by default)
+end
+
+# target :test do
+#   signature "sig", "sig-private"
+#
+#   check "test"
+#
+#   # library "pathname"              # Standard libraries
+# end

--- a/language_server-protocol.gemspec
+++ b/language_server-protocol.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/mtsmfm/language_server-protocol-ruby"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z lib LICENSE.txt README.md`.split("\x0")
+  spec.files         = `git ls-files -z lib sig LICENSE.txt README.md`.split("\x0")
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,0 +1,172 @@
+---
+path: ".gem_rbs_collection"
+gems:
+- name: abbrev
+  version: '0'
+  source:
+    type: stdlib
+- name: activesupport
+  version: '7.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: base64
+  version: '0'
+  source:
+    type: stdlib
+- name: bigdecimal
+  version: '0'
+  source:
+    type: stdlib
+- name: concurrent-ruby
+  version: '1.1'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: connection_pool
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: csv
+  version: '0'
+  source:
+    type: stdlib
+- name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: erb
+  version: '0'
+  source:
+    type: stdlib
+- name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: forwardable
+  version: '0'
+  source:
+    type: stdlib
+- name: i18n
+  version: '1.10'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: json
+  version: '0'
+  source:
+    type: stdlib
+- name: listen
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: logger
+  version: '0'
+  source:
+    type: stdlib
+- name: minitest
+  version: '0'
+  source:
+    type: stdlib
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: optparse
+  version: '0'
+  source:
+    type: stdlib
+- name: parser
+  version: '3.2'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: pathname
+  version: '0'
+  source:
+    type: stdlib
+- name: rainbow
+  version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rake
+  version: '13.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 438153d157e1e1ed6b640da973e33f333e57e6d9
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rbs
+  version: 3.4.4
+  source:
+    type: rubygems
+- name: rdoc
+  version: '0'
+  source:
+    type: stdlib
+- name: securerandom
+  version: '0'
+  source:
+    type: stdlib
+- name: singleton
+  version: '0'
+  source:
+    type: stdlib
+- name: steep
+  version: 1.6.0
+  source:
+    type: rubygems
+- name: strscan
+  version: '0'
+  source:
+    type: stdlib
+- name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: timeout
+  version: '0'
+  source:
+    type: stdlib
+- name: tsort
+  version: '0'
+  source:
+    type: stdlib
+gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -1,0 +1,19 @@
+# Download sources
+sources:
+  - type: git
+    name: ruby/gem_rbs_collection
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    revision: main
+    repo_dir: gems
+
+# You can specify local directories as sources also.
+# - type: local
+#   path: path/to/your/local/repository
+
+# A directory to install the downloaded RBSs
+path: .gem_rbs_collection
+
+gems:
+  # If you want to avoid installing rbs files for gems, you can specify them here.
+  - name: language_server-protocol
+    ignore: true

--- a/sig/language_server/protocol/constant/code_action_kind.rbs
+++ b/sig/language_server/protocol/constant/code_action_kind.rbs
@@ -1,0 +1,85 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The kind of a code action.
+      #
+      # Kinds are a hierarchical list of identifiers separated by `.`,
+      # e.g. `"refactor.extract.function"`.
+      #
+      # The set of kinds is open and client needs to announce the kinds it supports
+      # to the server during initialization.
+      # A set of predefined code action kinds.
+      #
+      module CodeActionKind
+        #
+        # Empty kind.
+        #
+        EMPTY: ''
+        #
+        # Base kind for quickfix actions: 'quickfix'.
+        #
+        QUICK_FIX: 'quickfix'
+        #
+        # Base kind for refactoring actions: 'refactor'.
+        #
+        REFACTOR: 'refactor'
+        #
+        # Base kind for refactoring extraction actions: 'refactor.extract'.
+        #
+        # Example extract actions:
+        #
+        # - Extract method
+        # - Extract function
+        # - Extract variable
+        # - Extract interface from class
+        # - ...
+        #
+        REFACTOR_EXTRACT: 'refactor.extract'
+        #
+        # Base kind for refactoring inline actions: 'refactor.inline'.
+        #
+        # Example inline actions:
+        #
+        # - Inline function
+        # - Inline variable
+        # - Inline constant
+        # - ...
+        #
+        REFACTOR_INLINE: 'refactor.inline'
+        #
+        # Base kind for refactoring rewrite actions: 'refactor.rewrite'.
+        #
+        # Example rewrite actions:
+        #
+        # - Convert JavaScript function to class
+        # - Add or remove parameter
+        # - Encapsulate field
+        # - Make method static
+        # - Move method to base class
+        # - ...
+        #
+        REFACTOR_REWRITE: 'refactor.rewrite'
+        #
+        # Base kind for source actions: `source`.
+        #
+        # Source code actions apply to the entire file.
+        #
+        SOURCE: 'source'
+        #
+        # Base kind for an organize imports source action:
+        # `source.organizeImports`.
+        #
+        SOURCE_ORGANIZE_IMPORTS: 'source.organizeImports'
+        #
+        # Base kind for a 'fix all' source action: `source.fixAll`.
+        #
+        # 'Fix all' actions automatically fix errors that have a clear fix that
+        # do not require user input. They should not suppress errors or perform
+        # unsafe fixes such as generating new types or classes.
+        #
+        SOURCE_FIX_ALL: 'source.fixAll'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/code_action_trigger_kind.rbs
+++ b/sig/language_server/protocol/constant/code_action_trigger_kind.rbs
@@ -1,0 +1,22 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The reason why code actions were requested.
+      #
+      module CodeActionTriggerKind
+        #
+        # Code actions were explicitly requested by the user or by an extension.
+        #
+        INVOKED: 1
+        #
+        # Code actions were requested automatically.
+        #
+        # This typically happens when current selection in a file changes, but can
+        # also be triggered when file content changes.
+        #
+        AUTOMATIC: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/completion_item_kind.rbs
+++ b/sig/language_server/protocol/constant/completion_item_kind.rbs
@@ -1,0 +1,36 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The kind of a completion entry.
+      #
+      module CompletionItemKind
+        TEXT: 1
+        METHOD: 2
+        FUNCTION: 3
+        CONSTRUCTOR: 4
+        FIELD: 5
+        VARIABLE: 6
+        CLASS: 7
+        INTERFACE: 8
+        MODULE: 9
+        PROPERTY: 10
+        UNIT: 11
+        VALUE: 12
+        ENUM: 13
+        KEYWORD: 14
+        SNIPPET: 15
+        COLOR: 16
+        FILE: 17
+        REFERENCE: 18
+        FOLDER: 19
+        ENUM_MEMBER: 20
+        CONSTANT: 21
+        STRUCT: 22
+        EVENT: 23
+        OPERATOR: 24
+        TYPE_PARAMETER: 25
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/completion_item_tag.rbs
+++ b/sig/language_server/protocol/constant/completion_item_tag.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Completion item tags are extra annotations that tweak the rendering of a
+      # completion item.
+      #
+      module CompletionItemTag
+        #
+        # Render a completion as obsolete, usually using a strike-out.
+        #
+        DEPRECATED: 1
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/completion_trigger_kind.rbs
+++ b/sig/language_server/protocol/constant/completion_trigger_kind.rbs
@@ -1,0 +1,26 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # How a completion was triggered
+      #
+      module CompletionTriggerKind
+        #
+        # Completion was triggered by typing an identifier (24x7 code
+        # complete), manual invocation (e.g Ctrl+Space) or via API.
+        #
+        INVOKED: 1
+        #
+        # Completion was triggered by a trigger character specified by
+        # the `triggerCharacters` properties of the
+        # `CompletionRegistrationOptions`.
+        #
+        TRIGGER_CHARACTER: 2
+        #
+        # Completion was re-triggered as the current completion list is incomplete.
+        #
+        TRIGGER_FOR_INCOMPLETE_COMPLETIONS: 3
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/diagnostic_severity.rbs
+++ b/sig/language_server/protocol/constant/diagnostic_severity.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module DiagnosticSeverity
+        #
+        # Reports an error.
+        #
+        ERROR: 1
+        #
+        # Reports a warning.
+        #
+        WARNING: 2
+        #
+        # Reports an information.
+        #
+        INFORMATION: 3
+        #
+        # Reports a hint.
+        #
+        HINT: 4
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/diagnostic_tag.rbs
+++ b/sig/language_server/protocol/constant/diagnostic_tag.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The diagnostic tags.
+      #
+      module DiagnosticTag
+        #
+        # Unused or unnecessary code.
+        #
+        # Clients are allowed to render diagnostics with this tag faded out
+        # instead of having an error squiggle.
+        #
+        UNNECESSARY: 1
+        #
+        # Deprecated or obsolete code.
+        #
+        # Clients are allowed to rendered diagnostics with this tag strike through.
+        #
+        DEPRECATED: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/document_diagnostic_report_kind.rbs
+++ b/sig/language_server/protocol/constant/document_diagnostic_report_kind.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The document diagnostic report kinds.
+      #
+      module DocumentDiagnosticReportKind
+        #
+        # A diagnostic report with a full
+        # set of problems.
+        #
+        FULL: 'full'
+        #
+        # A report indicating that the last
+        # returned report is still accurate.
+        #
+        UNCHANGED: 'unchanged'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/document_highlight_kind.rbs
+++ b/sig/language_server/protocol/constant/document_highlight_kind.rbs
@@ -1,0 +1,23 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # A document highlight kind.
+      #
+      module DocumentHighlightKind
+        #
+        # A textual occurrence.
+        #
+        TEXT: 1
+        #
+        # Read-access of a symbol, like reading a variable.
+        #
+        READ: 2
+        #
+        # Write-access of a symbol, like writing to a variable.
+        #
+        WRITE: 3
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/error_codes.rbs
+++ b/sig/language_server/protocol/constant/error_codes.rbs
@@ -1,0 +1,73 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module ErrorCodes
+        PARSE_ERROR: -32700
+        INVALID_REQUEST: -32600
+        METHOD_NOT_FOUND: -32601
+        INVALID_PARAMS: -32602
+        INTERNAL_ERROR: -32603
+        #
+        # This is the start range of JSON-RPC reserved error codes.
+        # It doesn't denote a real error code. No LSP error codes should
+        # be defined between the start and end range. For backwards
+        # compatibility the `ServerNotInitialized` and the `UnknownErrorCode`
+        # are left in the range.
+        #
+        JSONRPC_RESERVED_ERROR_RANGE_START: -32099
+        SERVER_ERROR_START: Integer
+        #
+        # Error code indicating that a server received a notification or
+        # request before the server has received the `initialize` request.
+        #
+        SERVER_NOT_INITIALIZED: -32002
+        UNKNOWN_ERROR_CODE: -32001
+        #
+        # This is the end range of JSON-RPC reserved error codes.
+        # It doesn't denote a real error code.
+        #
+        JSONRPC_RESERVED_ERROR_RANGE_END: -32000
+        SERVER_ERROR_END: Integer
+        #
+        # This is the start range of LSP reserved error codes.
+        # It doesn't denote a real error code.
+        #
+        LSP_RESERVED_ERROR_RANGE_START: -32899
+        #
+        # A request failed but it was syntactically correct, e.g the
+        # method name was known and the parameters were valid. The error
+        # message should contain human readable information about why
+        # the request failed.
+        #
+        REQUEST_FAILED: -32803
+        #
+        # The server cancelled the request. This error code should
+        # only be used for requests that explicitly support being
+        # server cancellable.
+        #
+        SERVER_CANCELLED: -32802
+        #
+        # The server detected that the content of a document got
+        # modified outside normal conditions. A server should
+        # NOT send this error code if it detects a content change
+        # in it unprocessed messages. The result even computed
+        # on an older state might still be useful for the client.
+        #
+        # If a client decides that a result is not of any use anymore
+        # the client should cancel the request.
+        #
+        CONTENT_MODIFIED: -32801
+        #
+        # The client has canceled a request and a server as detected
+        # the cancel.
+        #
+        REQUEST_CANCELLED: -32800
+        #
+        # This is the end range of LSP reserved error codes.
+        # It doesn't denote a real error code.
+        #
+        LSP_RESERVED_ERROR_RANGE_END: -32800
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/failure_handling_kind.rbs
+++ b/sig/language_server/protocol/constant/failure_handling_kind.rbs
@@ -1,0 +1,30 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module FailureHandlingKind
+        #
+        # Applying the workspace change is simply aborted if one of the changes
+        # provided fails. All operations executed before the failing operation
+        # stay executed.
+        #
+        ABORT: 'abort'
+        #
+        # All operations are executed transactional. That means they either all
+        # succeed or no changes at all are applied to the workspace.
+        #
+        TRANSACTIONAL: 'transactional'
+        #
+        # If the workspace edit contains only textual file changes they are
+        # executed transactional. If resource changes (create, rename or delete
+        # file) are part of the change the failure handling strategy is abort.
+        #
+        TEXT_ONLY_TRANSACTIONAL: 'textOnlyTransactional'
+        #
+        # The client tries to undo the operations already executed. But there is no
+        # guarantee that this is succeeding.
+        #
+        UNDO: 'undo'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/file_change_type.rbs
+++ b/sig/language_server/protocol/constant/file_change_type.rbs
@@ -1,0 +1,23 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The file event type.
+      #
+      module FileChangeType
+        #
+        # The file got created.
+        #
+        CREATED: 1
+        #
+        # The file got changed.
+        #
+        CHANGED: 2
+        #
+        # The file got deleted.
+        #
+        DELETED: 3
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/file_operation_pattern_kind.rbs
+++ b/sig/language_server/protocol/constant/file_operation_pattern_kind.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # A pattern kind describing if a glob pattern matches a file a folder or
+      # both.
+      #
+      module FileOperationPatternKind
+        #
+        # The pattern matches a file only.
+        #
+        FILE: 'file'
+        #
+        # The pattern matches a folder only.
+        #
+        FOLDER: 'folder'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/folding_range_kind.rbs
+++ b/sig/language_server/protocol/constant/folding_range_kind.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # A set of predefined range kinds.
+      # The type is a string since the value set is extensible
+      #
+      module FoldingRangeKind
+        #
+        # Folding range for a comment
+        #
+        COMMENT: 'comment'
+        #
+        # Folding range for imports or includes
+        #
+        IMPORTS: 'imports'
+        #
+        # Folding range for a region (e.g. `#region`)
+        #
+        REGION: 'region'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/initialize_error_codes.rbs
+++ b/sig/language_server/protocol/constant/initialize_error_codes.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Known error codes for an `InitializeErrorCodes`;
+      #
+      module InitializeErrorCodes
+        #
+        # If the protocol version provided by the client can't be handled by
+        # the server.
+        #
+        UNKNOWN_PROTOCOL_VERSION: 1
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/inlay_hint_kind.rbs
+++ b/sig/language_server/protocol/constant/inlay_hint_kind.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Inlay hint kinds.
+      #
+      module InlayHintKind
+        #
+        # An inlay hint that for a type annotation.
+        #
+        TYPE: 1
+        #
+        # An inlay hint that is for a parameter.
+        #
+        PARAMETER: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/insert_text_format.rbs
+++ b/sig/language_server/protocol/constant/insert_text_format.rbs
@@ -1,0 +1,25 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Defines whether the insert text in a completion item should be interpreted as
+      # plain text or a snippet.
+      #
+      module InsertTextFormat
+        #
+        # The primary text to be inserted is treated as a plain string.
+        #
+        PLAIN_TEXT: 1
+        #
+        # The primary text to be inserted is treated as a snippet.
+        #
+        # A snippet can define tab stops and placeholders with `$1`, `$2`
+        # and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+        # the end of the snippet. Placeholders with equal identifiers are linked,
+        # that is typing in one will update others too.
+        #
+        SNIPPET: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/insert_text_mode.rbs
+++ b/sig/language_server/protocol/constant/insert_text_mode.rbs
@@ -1,0 +1,30 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # How whitespace and indentation is handled during completion
+      # item insertion.
+      #
+      module InsertTextMode
+        #
+        # The insertion or replace strings is taken as it is. If the
+        # value is multi line the lines below the cursor will be
+        # inserted using the indentation defined in the string value.
+        # The client will not apply any kind of adjustments to the
+        # string.
+        #
+        AS_IS: 1
+        #
+        # The editor adjusts leading whitespace of new lines so that
+        # they match the indentation up to the cursor of the line for
+        # which the item is accepted.
+        #
+        # Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
+        # multi line completion item is indented using 2 tabs and all
+        # following lines inserted will be indented using 2 tabs as well.
+        #
+        ADJUST_INDENTATION: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/markup_kind.rbs
+++ b/sig/language_server/protocol/constant/markup_kind.rbs
@@ -1,0 +1,23 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Describes the content type that a client supports in various
+      # result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+      #
+      # Please note that `MarkupKinds` must not start with a `$`. This kinds
+      # are reserved for internal usage.
+      #
+      module MarkupKind
+        #
+        # Plain text is supported as a content format
+        #
+        PLAIN_TEXT: 'plaintext'
+        #
+        # Markdown is supported as a content format
+        #
+        MARKDOWN: 'markdown'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/message_type.rbs
+++ b/sig/language_server/protocol/constant/message_type.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module MessageType
+        #
+        # An error message.
+        #
+        ERROR: 1
+        #
+        # A warning message.
+        #
+        WARNING: 2
+        #
+        # An information message.
+        #
+        INFO: 3
+        #
+        # A log message.
+        #
+        LOG: 4
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/moniker_kind.rbs
+++ b/sig/language_server/protocol/constant/moniker_kind.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The moniker kind.
+      #
+      module MonikerKind
+        #
+        # The moniker represent a symbol that is imported into a project
+        #
+        IMPORT: 'import'
+        #
+        # The moniker represents a symbol that is exported from a project
+        #
+        EXPORT: 'export'
+        #
+        # The moniker represents a symbol that is local to a project (e.g. a local
+        # variable of a function, a class not visible outside the project, ...)
+        #
+        LOCAL: 'local'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/notebook_cell_kind.rbs
+++ b/sig/language_server/protocol/constant/notebook_cell_kind.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # A notebook cell kind.
+      #
+      module NotebookCellKind
+        #
+        # A markup-cell is formatted source that is used for display.
+        #
+        MARKUP: 1
+        #
+        # A code-cell is source code.
+        #
+        CODE: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/position_encoding_kind.rbs
+++ b/sig/language_server/protocol/constant/position_encoding_kind.rbs
@@ -1,0 +1,32 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # A type indicating how positions are encoded,
+      # specifically what column offsets mean.
+      # A set of predefined position encoding kinds.
+      #
+      module PositionEncodingKind
+        #
+        # Character offsets count UTF-8 code units (e.g bytes).
+        #
+        UTF8: 'utf-8'
+        #
+        # Character offsets count UTF-16 code units.
+        #
+        # This is the default and must always be supported
+        # by servers
+        #
+        UTF16: 'utf-16'
+        #
+        # Character offsets count UTF-32 code units.
+        #
+        # Implementation note: these are the same as Unicode code points,
+        # so this `PositionEncodingKind` may also be used for an
+        # encoding-agnostic representation of character offsets.
+        #
+        UTF32: 'utf-32'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/prepare_support_default_behavior.rbs
+++ b/sig/language_server/protocol/constant/prepare_support_default_behavior.rbs
@@ -1,0 +1,13 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module PrepareSupportDefaultBehavior
+        #
+        # The client's default behavior is to select the identifier
+        # according to the language's syntax rule.
+        #
+        IDENTIFIER: 1
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/resource_operation_kind.rbs
+++ b/sig/language_server/protocol/constant/resource_operation_kind.rbs
@@ -1,0 +1,23 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # The kind of resource operations supported by the client.
+      #
+      module ResourceOperationKind
+        #
+        # Supports creating new files and folders.
+        #
+        CREATE: 'create'
+        #
+        # Supports renaming existing files and folders.
+        #
+        RENAME: 'rename'
+        #
+        # Supports deleting existing files and folders.
+        #
+        DELETE: 'delete'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/semantic_token_modifiers.rbs
+++ b/sig/language_server/protocol/constant/semantic_token_modifiers.rbs
@@ -1,0 +1,18 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module SemanticTokenModifiers
+        DECLARATION: 'declaration'
+        DEFINITION: 'definition'
+        READONLY: 'readonly'
+        STATIC: 'static'
+        DEPRECATED: 'deprecated'
+        ABSTRACT: 'abstract'
+        ASYNC: 'async'
+        MODIFICATION: 'modification'
+        DOCUMENTATION: 'documentation'
+        DEFAULT_LIBRARY: 'defaultLibrary'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/semantic_token_types.rbs
+++ b/sig/language_server/protocol/constant/semantic_token_types.rbs
@@ -1,0 +1,35 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module SemanticTokenTypes
+        NAMESPACE: 'namespace'
+        #
+        # Represents a generic type. Acts as a fallback for types which
+        # can't be mapped to a specific type like class or enum.
+        #
+        TYPE: 'type'
+        CLASS: 'class'
+        ENUM: 'enum'
+        INTERFACE: 'interface'
+        STRUCT: 'struct'
+        TYPE_PARAMETER: 'typeParameter'
+        PARAMETER: 'parameter'
+        VARIABLE: 'variable'
+        PROPERTY: 'property'
+        ENUM_MEMBER: 'enumMember'
+        EVENT: 'event'
+        FUNCTION: 'function'
+        METHOD: 'method'
+        MACRO: 'macro'
+        KEYWORD: 'keyword'
+        MODIFIER: 'modifier'
+        COMMENT: 'comment'
+        STRING: 'string'
+        NUMBER: 'number'
+        REGEXP: 'regexp'
+        OPERATOR: 'operator'
+        DECORATOR: 'decorator'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/signature_help_trigger_kind.rbs
+++ b/sig/language_server/protocol/constant/signature_help_trigger_kind.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # How a signature help was triggered.
+      #
+      module SignatureHelpTriggerKind
+        #
+        # Signature help was invoked manually by the user or by a command.
+        #
+        INVOKED: 1
+        #
+        # Signature help was triggered by a trigger character.
+        #
+        TRIGGER_CHARACTER: 2
+        #
+        # Signature help was triggered by the cursor moving or by the document
+        # content changing.
+        #
+        CONTENT_CHANGE: 3
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/symbol_kind.rbs
+++ b/sig/language_server/protocol/constant/symbol_kind.rbs
@@ -1,0 +1,37 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # A symbol kind.
+      #
+      module SymbolKind
+        FILE: 1
+        MODULE: 2
+        NAMESPACE: 3
+        PACKAGE: 4
+        CLASS: 5
+        METHOD: 6
+        PROPERTY: 7
+        FIELD: 8
+        CONSTRUCTOR: 9
+        ENUM: 10
+        INTERFACE: 11
+        FUNCTION: 12
+        VARIABLE: 13
+        CONSTANT: 14
+        STRING: 15
+        NUMBER: 16
+        BOOLEAN: 17
+        ARRAY: 18
+        OBJECT: 19
+        KEY: 20
+        NULL: 21
+        ENUM_MEMBER: 22
+        STRUCT: 23
+        EVENT: 24
+        OPERATOR: 25
+        TYPE_PARAMETER: 26
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/symbol_tag.rbs
+++ b/sig/language_server/protocol/constant/symbol_tag.rbs
@@ -1,0 +1,15 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Symbol tags are extra annotations that tweak the rendering of a symbol.
+      #
+      module SymbolTag
+        #
+        # Render a symbol as obsolete, usually using a strike-out.
+        #
+        DEPRECATED: 1
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/text_document_save_reason.rbs
+++ b/sig/language_server/protocol/constant/text_document_save_reason.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Represents reasons why a text document is saved.
+      #
+      module TextDocumentSaveReason
+        #
+        # Manually triggered, e.g. by the user pressing save, by starting
+        # debugging, or by an API call.
+        #
+        MANUAL: 1
+        #
+        # Automatic after a delay.
+        #
+        AFTER_DELAY: 2
+        #
+        # When the editor lost focus.
+        #
+        FOCUS_OUT: 3
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/text_document_sync_kind.rbs
+++ b/sig/language_server/protocol/constant/text_document_sync_kind.rbs
@@ -1,0 +1,27 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Defines how the host (editor) should sync document changes to the language
+      # server.
+      #
+      module TextDocumentSyncKind
+        #
+        # Documents should not be synced at all.
+        #
+        NONE: 0
+        #
+        # Documents are synced by always sending the full content
+        # of the document.
+        #
+        FULL: 1
+        #
+        # Documents are synced by sending the full content on open.
+        # After that only incremental updates to the document are
+        # sent.
+        #
+        INCREMENTAL: 2
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/token_format.rbs
+++ b/sig/language_server/protocol/constant/token_format.rbs
@@ -1,0 +1,9 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module TokenFormat
+        RELATIVE: 'relative'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/uniqueness_level.rbs
+++ b/sig/language_server/protocol/constant/uniqueness_level.rbs
@@ -1,0 +1,31 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      #
+      # Moniker uniqueness level to define scope of the moniker.
+      #
+      module UniquenessLevel
+        #
+        # The moniker is only unique inside a document
+        #
+        DOCUMENT: 'document'
+        #
+        # The moniker is unique inside a project for which a dump got created
+        #
+        PROJECT: 'project'
+        #
+        # The moniker is unique inside the group to which a project belongs
+        #
+        GROUP: 'group'
+        #
+        # The moniker is unique inside the moniker scheme.
+        #
+        SCHEME: 'scheme'
+        #
+        # The moniker is globally unique
+        #
+        GLOBAL: 'global'
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/constant/watch_kind.rbs
+++ b/sig/language_server/protocol/constant/watch_kind.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Constant
+      module WatchKind
+        #
+        # Interested in create events.
+        #
+        CREATE: 1
+        #
+        # Interested in change events
+        #
+        CHANGE: 2
+        #
+        # Interested in delete events
+        #
+        DELETE: 4
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/annotated_text_edit.rbs
+++ b/sig/language_server/protocol/interface/annotated_text_edit.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A special text edit with an additional change annotation.
+      #
+      class AnnotatedTextEdit
+        def initialize: (range: untyped, new_text: String, annotation_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/apply_workspace_edit_params.rbs
+++ b/sig/language_server/protocol/interface/apply_workspace_edit_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ApplyWorkspaceEditParams
+        def initialize: (?label: String, edit: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/apply_workspace_edit_result.rbs
+++ b/sig/language_server/protocol/interface/apply_workspace_edit_result.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ApplyWorkspaceEditResult
+        def initialize: (applied: bool, ?failure_reason: String, ?failed_change: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_incoming_call.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_incoming_call.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyIncomingCall
+        def initialize: (from: untyped, from_ranges: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_incoming_calls_params.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_incoming_calls_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyIncomingCallsParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_item.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_item.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyItem
+        def initialize: (name: String, kind: untyped, ?tags: Array[untyped], ?detail: String, uri: String, range: untyped, selection_range: untyped, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_options.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_outgoing_call.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_outgoing_call.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyOutgoingCall
+        def initialize: (to: untyped, from_ranges: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_outgoing_calls_params.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_outgoing_calls_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyOutgoingCallsParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_prepare_params.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_prepare_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyPrepareParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/call_hierarchy_registration_options.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CallHierarchyRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/cancel_params.rbs
+++ b/sig/language_server/protocol/interface/cancel_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CancelParams
+        def initialize: (id: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/change_annotation.rbs
+++ b/sig/language_server/protocol/interface/change_annotation.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Additional information that describes document changes.
+      #
+      class ChangeAnnotation
+        def initialize: (label: String, ?needs_confirmation: bool, ?description: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ClientCapabilities
+        def initialize: (?workspace: untyped, ?text_document: untyped, ?notebook_document: untyped, ?window: untyped, ?general: untyped, ?experimental: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_action.rbs
+++ b/sig/language_server/protocol/interface/code_action.rbs
@@ -1,0 +1,23 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A code action represents a change that can be performed in code, e.g. to fix
+      # a problem or to refactor code.
+      #
+      # A CodeAction must set either `edit` and/or a `command`. If both are supplied,
+      # the `edit` is applied first, then the `command` is executed.
+      #
+      class CodeAction
+        def initialize: (title: String, ?kind: String, ?diagnostics: Array[untyped], ?is_preferred: bool, ?disabled: untyped, ?edit: untyped, ?command: untyped, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_action_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/code_action_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeActionClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?code_action_literal_support: untyped, ?is_preferred_support: bool, ?disabled_support: bool, ?data_support: bool, ?resolve_support: untyped, ?honors_change_annotations: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_action_context.rbs
+++ b/sig/language_server/protocol/interface/code_action_context.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Contains additional diagnostic information about the context in which
+      # a code action is run.
+      #
+      class CodeActionContext
+        def initialize: (diagnostics: Array[untyped], ?only: Array[String], ?trigger_kind: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_action_options.rbs
+++ b/sig/language_server/protocol/interface/code_action_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeActionOptions
+        def initialize: (?work_done_progress: bool, ?code_action_kinds: Array[String], ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_action_params.rbs
+++ b/sig/language_server/protocol/interface/code_action_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Params for the CodeActionRequest
+      #
+      class CodeActionParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped, range: untyped, context: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_action_registration_options.rbs
+++ b/sig/language_server/protocol/interface/code_action_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeActionRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?code_action_kinds: Array[String], ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_description.rbs
+++ b/sig/language_server/protocol/interface/code_description.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Structure to capture a description for an error code.
+      #
+      class CodeDescription
+        def initialize: (href: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_lens.rbs
+++ b/sig/language_server/protocol/interface/code_lens.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A code lens represents a command that should be shown along with
+      # source text, like the number of references, a way to run tests, etc.
+      #
+      # A code lens is _unresolved_ when no command is associated to it. For
+      # performance reasons the creation of a code lens and resolving should be done
+      # in two stages.
+      #
+      class CodeLens
+        def initialize: (range: untyped, ?command: untyped, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_lens_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/code_lens_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeLensClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_lens_options.rbs
+++ b/sig/language_server/protocol/interface/code_lens_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeLensOptions
+        def initialize: (?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_lens_params.rbs
+++ b/sig/language_server/protocol/interface/code_lens_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeLensParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_lens_registration_options.rbs
+++ b/sig/language_server/protocol/interface/code_lens_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeLensRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/code_lens_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/code_lens_workspace_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CodeLensWorkspaceClientCapabilities
+        def initialize: (?refresh_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/color.rbs
+++ b/sig/language_server/protocol/interface/color.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents a color in RGBA space.
+      #
+      class Color
+        def initialize: (red: Integer, green: Integer, blue: Integer, alpha: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/color_information.rbs
+++ b/sig/language_server/protocol/interface/color_information.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ColorInformation
+        def initialize: (range: untyped, color: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/color_presentation.rbs
+++ b/sig/language_server/protocol/interface/color_presentation.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ColorPresentation
+        def initialize: (label: String, ?text_edit: untyped, ?additional_text_edits: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/color_presentation_params.rbs
+++ b/sig/language_server/protocol/interface/color_presentation_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ColorPresentationParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped, color: untyped, range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/command.rbs
+++ b/sig/language_server/protocol/interface/command.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class Command
+        def initialize: (title: String, command: String, ?arguments: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/completion_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CompletionClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?completion_item: untyped, ?completion_item_kind: untyped, ?context_support: bool, ?insert_text_mode: untyped, ?completion_list: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_context.rbs
+++ b/sig/language_server/protocol/interface/completion_context.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Contains additional information about the context in which a completion
+      # request is triggered.
+      #
+      class CompletionContext
+        def initialize: (trigger_kind: untyped, ?trigger_character: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_item.rbs
+++ b/sig/language_server/protocol/interface/completion_item.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CompletionItem
+        def initialize: (label: String, ?label_details: untyped, ?kind: untyped, ?tags: Array[untyped], ?detail: String, ?documentation: untyped, ?deprecated: bool, ?preselect: bool, ?sort_text: String, ?filter_text: String, ?insert_text: String, ?insert_text_format: untyped, ?insert_text_mode: untyped, ?text_edit: untyped, ?text_edit_text: String, ?additional_text_edits: Array[untyped], ?commit_characters: Array[String], ?command: untyped, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_item_label_details.rbs
+++ b/sig/language_server/protocol/interface/completion_item_label_details.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Additional details for a completion item label.
+      #
+      class CompletionItemLabelDetails
+        def initialize: (?detail: String, ?description: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_list.rbs
+++ b/sig/language_server/protocol/interface/completion_list.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents a collection of [completion items](#CompletionItem) to be
+      # presented in the editor.
+      #
+      class CompletionList
+        def initialize: (is_incomplete: bool, ?item_defaults: untyped, items: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_options.rbs
+++ b/sig/language_server/protocol/interface/completion_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Completion options.
+      #
+      class CompletionOptions
+        def initialize: (?work_done_progress: bool, ?trigger_characters: Array[String], ?all_commit_characters: Array[String], ?resolve_provider: bool, ?completion_item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_params.rbs
+++ b/sig/language_server/protocol/interface/completion_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CompletionParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped, ?context: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/completion_registration_options.rbs
+++ b/sig/language_server/protocol/interface/completion_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class CompletionRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?trigger_characters: Array[String], ?all_commit_characters: Array[String], ?resolve_provider: bool, ?completion_item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/configuration_item.rbs
+++ b/sig/language_server/protocol/interface/configuration_item.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ConfigurationItem
+        def initialize: (?scope_uri: String, ?section: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/configuration_params.rbs
+++ b/sig/language_server/protocol/interface/configuration_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ConfigurationParams
+        def initialize: (items: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/create_file.rbs
+++ b/sig/language_server/protocol/interface/create_file.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Create file operation
+      #
+      class CreateFile
+        def initialize: (kind: untyped, uri: String, ?options: untyped, ?annotation_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/create_file_options.rbs
+++ b/sig/language_server/protocol/interface/create_file_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Options to create a file.
+      #
+      class CreateFileOptions
+        def initialize: (?overwrite: bool, ?ignore_if_exists: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/create_files_params.rbs
+++ b/sig/language_server/protocol/interface/create_files_params.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The parameters sent in notifications/requests for user-initiated creation
+      # of files.
+      #
+      class CreateFilesParams
+        def initialize: (files: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/declaration_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/declaration_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DeclarationClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?link_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/declaration_options.rbs
+++ b/sig/language_server/protocol/interface/declaration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DeclarationOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/declaration_params.rbs
+++ b/sig/language_server/protocol/interface/declaration_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DeclarationParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/declaration_registration_options.rbs
+++ b/sig/language_server/protocol/interface/declaration_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DeclarationRegistrationOptions
+        def initialize: (?work_done_progress: bool, document_selector: untyped, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/definition_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/definition_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DefinitionClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?link_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/definition_options.rbs
+++ b/sig/language_server/protocol/interface/definition_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DefinitionOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/definition_params.rbs
+++ b/sig/language_server/protocol/interface/definition_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DefinitionParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/definition_registration_options.rbs
+++ b/sig/language_server/protocol/interface/definition_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DefinitionRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/delete_file.rbs
+++ b/sig/language_server/protocol/interface/delete_file.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Delete file operation
+      #
+      class DeleteFile
+        def initialize: (kind: untyped, uri: String, ?options: untyped, ?annotation_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/delete_file_options.rbs
+++ b/sig/language_server/protocol/interface/delete_file_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Delete file options
+      #
+      class DeleteFileOptions
+        def initialize: (?recursive: bool, ?ignore_if_not_exists: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/delete_files_params.rbs
+++ b/sig/language_server/protocol/interface/delete_files_params.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The parameters sent in notifications/requests for user-initiated deletes
+      # of files.
+      #
+      class DeleteFilesParams
+        def initialize: (files: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic.rbs
+++ b/sig/language_server/protocol/interface/diagnostic.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class Diagnostic
+        def initialize: (range: untyped, ?severity: untyped, ?code: untyped, ?code_description: untyped, ?source: String, message: String, ?tags: Array[untyped], ?related_information: Array[untyped], ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Client capabilities specific to diagnostic pull requests.
+      #
+      class DiagnosticClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?related_document_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic_options.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Diagnostic options.
+      #
+      class DiagnosticOptions
+        def initialize: (?work_done_progress: bool, ?identifier: String, inter_file_dependencies: bool, workspace_diagnostics: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic_registration_options.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Diagnostic registration options.
+      #
+      class DiagnosticRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?identifier: String, inter_file_dependencies: bool, workspace_diagnostics: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic_related_information.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_related_information.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents a related message and source code location for a diagnostic.
+      # This should be used to point to code locations that cause or are related to
+      # a diagnostics, e.g when duplicating a symbol in a scope.
+      #
+      class DiagnosticRelatedInformation
+        def initialize: (location: untyped, message: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic_server_cancellation_data.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_server_cancellation_data.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Cancellation data returned from a diagnostic request.
+      #
+      class DiagnosticServerCancellationData
+        def initialize: (retrigger_request: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/diagnostic_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_workspace_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Workspace client capabilities specific to diagnostic pull requests.
+      #
+      class DiagnosticWorkspaceClientCapabilities
+        def initialize: (?refresh_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_configuration_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/did_change_configuration_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidChangeConfigurationClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_configuration_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_configuration_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidChangeConfigurationParams
+        def initialize: (settings: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_notebook_document_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The params sent in a change notebook document notification.
+      #
+      class DidChangeNotebookDocumentParams
+        def initialize: (notebook_document: untyped, change: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_text_document_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidChangeTextDocumentParams
+        def initialize: (text_document: untyped, content_changes: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_watched_files_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/did_change_watched_files_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidChangeWatchedFilesClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?relative_pattern_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_watched_files_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_watched_files_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidChangeWatchedFilesParams
+        def initialize: (changes: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_watched_files_registration_options.rbs
+++ b/sig/language_server/protocol/interface/did_change_watched_files_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Describe options to be used when registering for file system change events.
+      #
+      class DidChangeWatchedFilesRegistrationOptions
+        def initialize: (watchers: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_change_workspace_folders_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_workspace_folders_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidChangeWorkspaceFoldersParams
+        def initialize: (event: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_close_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_close_notebook_document_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The params sent in a close notebook document notification.
+      #
+      class DidCloseNotebookDocumentParams
+        def initialize: (notebook_document: untyped, cell_text_documents: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_close_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_close_text_document_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidCloseTextDocumentParams
+        def initialize: (text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_open_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_open_notebook_document_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The params sent in an open notebook document notification.
+      #
+      class DidOpenNotebookDocumentParams
+        def initialize: (notebook_document: untyped, cell_text_documents: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_open_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_open_text_document_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidOpenTextDocumentParams
+        def initialize: (text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_save_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_save_notebook_document_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The params sent in a save notebook document notification.
+      #
+      class DidSaveNotebookDocumentParams
+        def initialize: (notebook_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/did_save_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_save_text_document_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DidSaveTextDocumentParams
+        def initialize: (text_document: untyped, ?text: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_color_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_color_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentColorClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_color_options.rbs
+++ b/sig/language_server/protocol/interface/document_color_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentColorOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_color_params.rbs
+++ b/sig/language_server/protocol/interface/document_color_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentColorParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_color_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_color_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentColorRegistrationOptions
+        def initialize: (document_selector: untyped, ?id: String, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_diagnostic_params.rbs
+++ b/sig/language_server/protocol/interface/document_diagnostic_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Parameters of the document diagnostic request.
+      #
+      class DocumentDiagnosticParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped, ?identifier: String, ?previous_result_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_diagnostic_report_partial_result.rbs
+++ b/sig/language_server/protocol/interface/document_diagnostic_report_partial_result.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A partial result for a document diagnostic report.
+      #
+      class DocumentDiagnosticReportPartialResult
+        def initialize: (related_documents: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_filter.rbs
+++ b/sig/language_server/protocol/interface/document_filter.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentFilter
+        def initialize: (?language: String, ?scheme: String, ?pattern: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_formatting_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentFormattingClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_formatting_options.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentFormattingOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_formatting_params.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentFormattingParams
+        def initialize: (?work_done_token: untyped, text_document: untyped, options: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_formatting_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentFormattingRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_highlight.rbs
+++ b/sig/language_server/protocol/interface/document_highlight.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A document highlight is a range inside a text document which deserves
+      # special attention. Usually a document highlight is visualized by changing
+      # the background color of its range.
+      #
+      class DocumentHighlight
+        def initialize: (range: untyped, ?kind: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_highlight_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentHighlightClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_highlight_options.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentHighlightOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_highlight_params.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentHighlightParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_highlight_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentHighlightRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_link.rbs
+++ b/sig/language_server/protocol/interface/document_link.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A document link is a range in a text document that links to an internal or
+      # external resource, like another text document or a web site.
+      #
+      class DocumentLink
+        def initialize: (range: untyped, ?target: String, ?tooltip: String, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_link_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_link_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentLinkClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?tooltip_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_link_options.rbs
+++ b/sig/language_server/protocol/interface/document_link_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentLinkOptions
+        def initialize: (?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_link_params.rbs
+++ b/sig/language_server/protocol/interface/document_link_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentLinkParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_link_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_link_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentLinkRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_on_type_formatting_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentOnTypeFormattingClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_on_type_formatting_options.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentOnTypeFormattingOptions
+        def initialize: (first_trigger_character: String, ?more_trigger_character: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_on_type_formatting_params.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentOnTypeFormattingParams
+        def initialize: (text_document: untyped, position: untyped, ch: String, options: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_on_type_formatting_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentOnTypeFormattingRegistrationOptions
+        def initialize: (document_selector: untyped, first_trigger_character: String, ?more_trigger_character: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_range_formatting_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentRangeFormattingClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_range_formatting_options.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentRangeFormattingOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_range_formatting_params.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentRangeFormattingParams
+        def initialize: (?work_done_token: untyped, text_document: untyped, range: untyped, options: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_range_formatting_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentRangeFormattingRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_symbol.rbs
+++ b/sig/language_server/protocol/interface/document_symbol.rbs
@@ -1,0 +1,22 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents programming constructs like variables, classes, interfaces etc.
+      # that appear in a document. Document symbols can be hierarchical and they
+      # have two ranges: one that encloses its definition and one that points to its
+      # most interesting range, e.g. the range of an identifier.
+      #
+      class DocumentSymbol
+        def initialize: (name: String, ?detail: String, kind: untyped, ?tags: Array[untyped], ?deprecated: bool, range: untyped, selection_range: untyped, ?children: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_symbol_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentSymbolClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?symbol_kind: untyped, ?hierarchical_document_symbol_support: bool, ?tag_support: untyped, ?label_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_symbol_options.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentSymbolOptions
+        def initialize: (?work_done_progress: bool, ?label: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_symbol_params.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentSymbolParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/document_symbol_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class DocumentSymbolRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?label: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/execute_command_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/execute_command_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ExecuteCommandClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/execute_command_options.rbs
+++ b/sig/language_server/protocol/interface/execute_command_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ExecuteCommandOptions
+        def initialize: (?work_done_progress: bool, commands: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/execute_command_params.rbs
+++ b/sig/language_server/protocol/interface/execute_command_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ExecuteCommandParams
+        def initialize: (?work_done_token: untyped, command: String, ?arguments: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/execute_command_registration_options.rbs
+++ b/sig/language_server/protocol/interface/execute_command_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Execute command registration options.
+      #
+      class ExecuteCommandRegistrationOptions
+        def initialize: (?work_done_progress: bool, commands: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/execution_summary.rbs
+++ b/sig/language_server/protocol/interface/execution_summary.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ExecutionSummary
+        def initialize: (execution_order: Integer, ?success: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_create.rbs
+++ b/sig/language_server/protocol/interface/file_create.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents information on a file/folder create.
+      #
+      class FileCreate
+        def initialize: (uri: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_delete.rbs
+++ b/sig/language_server/protocol/interface/file_delete.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents information on a file/folder delete.
+      #
+      class FileDelete
+        def initialize: (uri: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_event.rbs
+++ b/sig/language_server/protocol/interface/file_event.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # An event describing a file change.
+      #
+      class FileEvent
+        def initialize: (uri: String, type: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_operation_filter.rbs
+++ b/sig/language_server/protocol/interface/file_operation_filter.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A filter to describe in which file operation requests or notifications
+      # the server is interested in.
+      #
+      class FileOperationFilter
+        def initialize: (?scheme: String, pattern: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_operation_pattern.rbs
+++ b/sig/language_server/protocol/interface/file_operation_pattern.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A pattern to describe in which file operation requests or notifications
+      # the server is interested in.
+      #
+      class FileOperationPattern
+        def initialize: (glob: String, ?matches: untyped, ?options: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_operation_pattern_options.rbs
+++ b/sig/language_server/protocol/interface/file_operation_pattern_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Matching options for the file operation pattern.
+      #
+      class FileOperationPatternOptions
+        def initialize: (?ignore_case: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_operation_registration_options.rbs
+++ b/sig/language_server/protocol/interface/file_operation_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The options to register for file operations.
+      #
+      class FileOperationRegistrationOptions
+        def initialize: (filters: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_rename.rbs
+++ b/sig/language_server/protocol/interface/file_rename.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents information on a file/folder rename.
+      #
+      class FileRename
+        def initialize: (old_uri: String, new_uri: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/file_system_watcher.rbs
+++ b/sig/language_server/protocol/interface/file_system_watcher.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class FileSystemWatcher
+        def initialize: (glob_pattern: untyped, ?kind: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/folding_range.rbs
+++ b/sig/language_server/protocol/interface/folding_range.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents a folding range. To be valid, start and end line must be bigger
+      # than zero and smaller than the number of lines in the document. Clients
+      # are free to ignore invalid ranges.
+      #
+      class FoldingRange
+        def initialize: (start_line: Integer, ?start_character: Integer, end_line: Integer, ?end_character: Integer, ?kind: String, ?collapsed_text: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/folding_range_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/folding_range_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class FoldingRangeClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?range_limit: Integer, ?line_folding_only: bool, ?folding_range_kind: untyped, ?folding_range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/folding_range_options.rbs
+++ b/sig/language_server/protocol/interface/folding_range_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class FoldingRangeOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/folding_range_params.rbs
+++ b/sig/language_server/protocol/interface/folding_range_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class FoldingRangeParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/folding_range_registration_options.rbs
+++ b/sig/language_server/protocol/interface/folding_range_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class FoldingRangeRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/formatting_options.rbs
+++ b/sig/language_server/protocol/interface/formatting_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Value-object describing what options formatting should use.
+      #
+      class FormattingOptions
+        def initialize: (tab_size: Integer, insert_spaces: bool, ?trim_trailing_whitespace: bool, ?insert_final_newline: bool, ?trim_final_newlines: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/full_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/full_document_diagnostic_report.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A diagnostic report with a full set of problems.
+      #
+      class FullDocumentDiagnosticReport
+        def initialize: (kind: untyped, ?result_id: String, items: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/hover.rbs
+++ b/sig/language_server/protocol/interface/hover.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The result of a hover request.
+      #
+      class Hover
+        def initialize: (contents: Array[untyped], ?range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/hover_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/hover_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class HoverClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?content_format: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/hover_options.rbs
+++ b/sig/language_server/protocol/interface/hover_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class HoverOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/hover_params.rbs
+++ b/sig/language_server/protocol/interface/hover_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class HoverParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/hover_registration_options.rbs
+++ b/sig/language_server/protocol/interface/hover_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class HoverRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/hover_result.rbs
+++ b/sig/language_server/protocol/interface/hover_result.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class HoverResult
+        def initialize: (value: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/implementation_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/implementation_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ImplementationClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?link_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/implementation_options.rbs
+++ b/sig/language_server/protocol/interface/implementation_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ImplementationOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/implementation_params.rbs
+++ b/sig/language_server/protocol/interface/implementation_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ImplementationParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/implementation_registration_options.rbs
+++ b/sig/language_server/protocol/interface/implementation_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ImplementationRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/initialize_error.rbs
+++ b/sig/language_server/protocol/interface/initialize_error.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class InitializeError
+        def initialize: (retry: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/initialize_params.rbs
+++ b/sig/language_server/protocol/interface/initialize_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class InitializeParams
+        def initialize: (?work_done_token: untyped, process_id: Integer, ?client_info: untyped, ?locale: String, ?root_path: String, root_uri: String, ?initialization_options: untyped, capabilities: untyped, ?trace: untyped, ?workspace_folders: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/initialize_result.rbs
+++ b/sig/language_server/protocol/interface/initialize_result.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class InitializeResult
+        def initialize: (capabilities: untyped, ?server_info: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/initialized_params.rbs
+++ b/sig/language_server/protocol/interface/initialized_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class InitializedParams
+        def initialize: () -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Inlay hint information.
+      #
+      class InlayHint
+        def initialize: (position: untyped, label: Array[untyped], ?kind: untyped, ?text_edits: Array[untyped], ?tooltip: untyped, ?padding_left: bool, ?padding_right: bool, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Inlay hint client capabilities.
+      #
+      class InlayHintClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?resolve_support: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint_label_part.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_label_part.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # An inlay hint label part allows for interactive and composite labels
+      # of inlay hints.
+      #
+      class InlayHintLabelPart
+        def initialize: (value: String, ?tooltip: untyped, ?location: untyped, ?command: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint_options.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Inlay hint options used during static registration.
+      #
+      class InlayHintOptions
+        def initialize: (?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint_params.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A parameter literal used in inlay hint requests.
+      #
+      class InlayHintParams
+        def initialize: (?work_done_token: untyped, text_document: untyped, range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint_registration_options.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Inlay hint options used during static or dynamic registration.
+      #
+      class InlayHintRegistrationOptions
+        def initialize: (?work_done_progress: bool, ?resolve_provider: bool, document_selector: untyped, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inlay_hint_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_workspace_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Client workspace capabilities specific to inlay hints.
+      #
+      class InlayHintWorkspaceClientCapabilities
+        def initialize: (?refresh_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inline_value_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Client capabilities specific to inline values.
+      #
+      class InlineValueClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_context.rbs
+++ b/sig/language_server/protocol/interface/inline_value_context.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class InlineValueContext
+        def initialize: (frame_id: Integer, stopped_location: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_evaluatable_expression.rbs
+++ b/sig/language_server/protocol/interface/inline_value_evaluatable_expression.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Provide an inline value through an expression evaluation.
+      #
+      # If only a range is specified, the expression will be extracted from the
+      # underlying document.
+      #
+      # An optional expression can be used to override the extracted expression.
+      #
+      class InlineValueEvaluatableExpression
+        def initialize: (range: untyped, ?expression: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_options.rbs
+++ b/sig/language_server/protocol/interface/inline_value_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Inline value options used during static registration.
+      #
+      class InlineValueOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_params.rbs
+++ b/sig/language_server/protocol/interface/inline_value_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A parameter literal used in inline value requests.
+      #
+      class InlineValueParams
+        def initialize: (?work_done_token: untyped, text_document: untyped, range: untyped, context: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_registration_options.rbs
+++ b/sig/language_server/protocol/interface/inline_value_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Inline value options used during static or dynamic registration.
+      #
+      class InlineValueRegistrationOptions
+        def initialize: (?work_done_progress: bool, document_selector: untyped, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_text.rbs
+++ b/sig/language_server/protocol/interface/inline_value_text.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Provide inline value as text.
+      #
+      class InlineValueText
+        def initialize: (range: untyped, text: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_variable_lookup.rbs
+++ b/sig/language_server/protocol/interface/inline_value_variable_lookup.rbs
@@ -1,0 +1,24 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Provide inline value through a variable lookup.
+      #
+      # If only a range is specified, the variable name will be extracted from
+      # the underlying document.
+      #
+      # An optional variable name can be used to override the extracted name.
+      #
+      class InlineValueVariableLookup
+        def initialize: (range: untyped, ?variable_name: String, case_sensitive_lookup: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/inline_value_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inline_value_workspace_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Client workspace capabilities specific to inline values.
+      #
+      class InlineValueWorkspaceClientCapabilities
+        def initialize: (?refresh_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/insert_replace_edit.rbs
+++ b/sig/language_server/protocol/interface/insert_replace_edit.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A special text edit to provide an insert and a replace operation.
+      #
+      class InsertReplaceEdit
+        def initialize: (new_text: String, insert: untyped, replace: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/linked_editing_range_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LinkedEditingRangeClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/linked_editing_range_options.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LinkedEditingRangeOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/linked_editing_range_params.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LinkedEditingRangeParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/linked_editing_range_registration_options.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LinkedEditingRangeRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/linked_editing_ranges.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_ranges.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LinkedEditingRanges
+        def initialize: (ranges: Array[untyped], ?word_pattern: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/location.rbs
+++ b/sig/language_server/protocol/interface/location.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class Location
+        def initialize: (uri: String, range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/location_link.rbs
+++ b/sig/language_server/protocol/interface/location_link.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LocationLink
+        def initialize: (?origin_selection_range: untyped, target_uri: String, target_range: untyped, target_selection_range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/log_message_params.rbs
+++ b/sig/language_server/protocol/interface/log_message_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LogMessageParams
+        def initialize: (type: untyped, message: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/log_trace_params.rbs
+++ b/sig/language_server/protocol/interface/log_trace_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class LogTraceParams
+        def initialize: (message: String, ?verbose: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/markup_content.rbs
+++ b/sig/language_server/protocol/interface/markup_content.rbs
@@ -1,0 +1,42 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A `MarkupContent` literal represents a string value which content is
+      # interpreted base on its kind flag. Currently the protocol supports
+      # `plaintext` and `markdown` as markup kinds.
+      #
+      # If the kind is `markdown` then the value can contain fenced code blocks like
+      # in GitHub issues.
+      #
+      # Here is an example how such a string can be constructed using
+      # JavaScript / TypeScript:
+      # ```typescript
+      # let markdown: MarkdownContent = {
+      # kind: MarkupKind.Markdown,
+      # value: [
+      # '# Header',
+      # 'Some text',
+      # '```typescript',
+      # 'someCode();',
+      # '```'
+      # ].join('\n')
+      # };
+      # ```
+      #
+      # *Please Note* that clients might sanitize the return markdown. A client could
+      # decide to remove HTML from the markdown to avoid script execution.
+      #
+      class MarkupContent
+        def initialize: (kind: untyped, value: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/message.rbs
+++ b/sig/language_server/protocol/interface/message.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class Message
+        def initialize: (jsonrpc: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/message_action_item.rbs
+++ b/sig/language_server/protocol/interface/message_action_item.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class MessageActionItem
+        def initialize: (title: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/moniker.rbs
+++ b/sig/language_server/protocol/interface/moniker.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Moniker definition to match LSIF 0.5 moniker definition.
+      #
+      class Moniker
+        def initialize: (scheme: String, identifier: String, unique: untyped, ?kind: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/moniker_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/moniker_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class MonikerClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/moniker_options.rbs
+++ b/sig/language_server/protocol/interface/moniker_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class MonikerOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/moniker_params.rbs
+++ b/sig/language_server/protocol/interface/moniker_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class MonikerParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/moniker_registration_options.rbs
+++ b/sig/language_server/protocol/interface/moniker_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class MonikerRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_cell.rbs
+++ b/sig/language_server/protocol/interface/notebook_cell.rbs
@@ -1,0 +1,23 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A notebook cell.
+      #
+      # A cell's document URI must be unique across ALL notebook
+      # cells and can therefore be used to uniquely identify a
+      # notebook cell or the cell's text document.
+      #
+      class NotebookCell
+        def initialize: (kind: untyped, document: String, ?metadata: untyped, ?execution_summary: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_cell_array_change.rbs
+++ b/sig/language_server/protocol/interface/notebook_cell_array_change.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A change describing how to move a `NotebookCell`
+      # array from state S to S'.
+      #
+      class NotebookCellArrayChange
+        def initialize: (start: Integer, delete_count: Integer, ?cells: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_cell_text_document_filter.rbs
+++ b/sig/language_server/protocol/interface/notebook_cell_text_document_filter.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A notebook cell text document filter denotes a cell text
+      # document by different properties.
+      #
+      class NotebookCellTextDocumentFilter
+        def initialize: (notebook: untyped, ?language: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document.rbs
+++ b/sig/language_server/protocol/interface/notebook_document.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A notebook document.
+      #
+      class NotebookDocument
+        def initialize: (uri: String, notebook_type: String, version: Integer, ?metadata: untyped, cells: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_change_event.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_change_event.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A change event for a notebook document.
+      #
+      class NotebookDocumentChangeEvent
+        def initialize: (?metadata: untyped, ?cells: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Capabilities specific to the notebook document support.
+      #
+      class NotebookDocumentClientCapabilities
+        def initialize: (synchronization: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_filter.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_filter.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A notebook document filter denotes a notebook document by
+      # different properties.
+      #
+      class NotebookDocumentFilter
+        def initialize: (?notebook_type: String, ?scheme: String, ?pattern: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_identifier.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A literal to identify a notebook document in the client.
+      #
+      class NotebookDocumentIdentifier
+        def initialize: (uri: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_sync_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_sync_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Notebook specific client capabilities.
+      #
+      class NotebookDocumentSyncClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?execution_summary_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_sync_options.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_sync_options.rbs
@@ -1,0 +1,29 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Options specific to a notebook plus its cells
+      # to be synced to the server.
+      #
+      # If a selector provides a notebook document
+      # filter but no cell selector all cells of a
+      # matching notebook document will be synced.
+      #
+      # If a selector provides no notebook document
+      # filter but only a cell selector all notebook
+      # documents that contain at least one matching
+      # cell will be synced.
+      #
+      class NotebookDocumentSyncOptions
+        def initialize: (notebook_selector: Array[untyped], ?save: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notebook_document_sync_registration_options.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_sync_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Registration options specific to a notebook.
+      #
+      class NotebookDocumentSyncRegistrationOptions
+        def initialize: (notebook_selector: Array[untyped], ?save: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/notification_message.rbs
+++ b/sig/language_server/protocol/interface/notification_message.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class NotificationMessage
+        def initialize: (jsonrpc: String, method: String, ?params: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/optional_versioned_text_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/optional_versioned_text_document_identifier.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class OptionalVersionedTextDocumentIdentifier
+        def initialize: (uri: String, version: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/parameter_information.rbs
+++ b/sig/language_server/protocol/interface/parameter_information.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents a parameter of a callable-signature. A parameter can
+      # have a label and a doc-comment.
+      #
+      class ParameterInformation
+        def initialize: (label: untyped, ?documentation: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/partial_result_params.rbs
+++ b/sig/language_server/protocol/interface/partial_result_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class PartialResultParams
+        def initialize: (?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/position.rbs
+++ b/sig/language_server/protocol/interface/position.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class Position
+        def initialize: (line: Integer, character: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/prepare_rename_params.rbs
+++ b/sig/language_server/protocol/interface/prepare_rename_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class PrepareRenameParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/previous_result_id.rbs
+++ b/sig/language_server/protocol/interface/previous_result_id.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A previous result id in a workspace pull request.
+      #
+      class PreviousResultId
+        def initialize: (uri: String, value: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/progress_params.rbs
+++ b/sig/language_server/protocol/interface/progress_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ProgressParams
+        def initialize: (token: untyped, value: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/publish_diagnostics_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/publish_diagnostics_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class PublishDiagnosticsClientCapabilities
+        def initialize: (?related_information: bool, ?tag_support: untyped, ?version_support: bool, ?code_description_support: bool, ?data_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/publish_diagnostics_params.rbs
+++ b/sig/language_server/protocol/interface/publish_diagnostics_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class PublishDiagnosticsParams
+        def initialize: (uri: String, ?version: Integer, diagnostics: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/range.rbs
+++ b/sig/language_server/protocol/interface/range.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class Range
+        def initialize: (start: untyped, end: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/reference_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/reference_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ReferenceClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/reference_context.rbs
+++ b/sig/language_server/protocol/interface/reference_context.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ReferenceContext
+        def initialize: (include_declaration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/reference_options.rbs
+++ b/sig/language_server/protocol/interface/reference_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ReferenceOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/reference_params.rbs
+++ b/sig/language_server/protocol/interface/reference_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ReferenceParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped, context: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/reference_registration_options.rbs
+++ b/sig/language_server/protocol/interface/reference_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ReferenceRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/registration.rbs
+++ b/sig/language_server/protocol/interface/registration.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # General parameters to register for a capability.
+      #
+      class Registration
+        def initialize: (id: String, method: String, ?register_options: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/registration_params.rbs
+++ b/sig/language_server/protocol/interface/registration_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class RegistrationParams
+        def initialize: (registrations: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/regular_expressions_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/regular_expressions_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Client capabilities specific to regular expressions.
+      #
+      class RegularExpressionsClientCapabilities
+        def initialize: (engine: String, ?version: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/related_full_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/related_full_document_diagnostic_report.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A full diagnostic report with a set of related documents.
+      #
+      class RelatedFullDocumentDiagnosticReport
+        def initialize: (kind: untyped, ?result_id: String, items: Array[untyped], ?related_documents: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/related_unchanged_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/related_unchanged_document_diagnostic_report.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # An unchanged diagnostic report with a set of related documents.
+      #
+      class RelatedUnchangedDocumentDiagnosticReport
+        def initialize: (kind: untyped, result_id: String, ?related_documents: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/relative_pattern.rbs
+++ b/sig/language_server/protocol/interface/relative_pattern.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A relative pattern is a helper to construct glob patterns that are matched
+      # relatively to a base URI. The common value for a `baseUri` is a workspace
+      # folder root, but it can be another absolute URI as well.
+      #
+      class RelativePattern
+        def initialize: (base_uri: untyped, pattern: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/rename_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class RenameClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?prepare_support: bool, ?prepare_support_default_behavior: untyped, ?honors_change_annotations: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_file.rbs
+++ b/sig/language_server/protocol/interface/rename_file.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Rename file operation
+      #
+      class RenameFile
+        def initialize: (kind: untyped, old_uri: String, new_uri: String, ?options: untyped, ?annotation_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_file_options.rbs
+++ b/sig/language_server/protocol/interface/rename_file_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Rename file options
+      #
+      class RenameFileOptions
+        def initialize: (?overwrite: bool, ?ignore_if_exists: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_files_params.rbs
+++ b/sig/language_server/protocol/interface/rename_files_params.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The parameters sent in notifications/requests for user-initiated renames
+      # of files.
+      #
+      class RenameFilesParams
+        def initialize: (files: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_options.rbs
+++ b/sig/language_server/protocol/interface/rename_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class RenameOptions
+        def initialize: (?work_done_progress: bool, ?prepare_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_params.rbs
+++ b/sig/language_server/protocol/interface/rename_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class RenameParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, new_name: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/rename_registration_options.rbs
+++ b/sig/language_server/protocol/interface/rename_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class RenameRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?prepare_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/request_message.rbs
+++ b/sig/language_server/protocol/interface/request_message.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class RequestMessage
+        def initialize: (jsonrpc: String, id: untyped, method: String, ?params: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/response_error.rbs
+++ b/sig/language_server/protocol/interface/response_error.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ResponseError
+        def initialize: (code: Integer, message: String, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/response_message.rbs
+++ b/sig/language_server/protocol/interface/response_message.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ResponseMessage
+        def initialize: (jsonrpc: String, id: untyped, ?result: untyped, ?error: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/save_options.rbs
+++ b/sig/language_server/protocol/interface/save_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SaveOptions
+        def initialize: (?include_text: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/selection_range.rbs
+++ b/sig/language_server/protocol/interface/selection_range.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SelectionRange
+        def initialize: (range: untyped, ?parent: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/selection_range_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/selection_range_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SelectionRangeClientCapabilities
+        def initialize: (?dynamic_registration: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/selection_range_options.rbs
+++ b/sig/language_server/protocol/interface/selection_range_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SelectionRangeOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/selection_range_params.rbs
+++ b/sig/language_server/protocol/interface/selection_range_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SelectionRangeParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped, positions: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/selection_range_registration_options.rbs
+++ b/sig/language_server/protocol/interface/selection_range_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SelectionRangeRegistrationOptions
+        def initialize: (?work_done_progress: bool, document_selector: untyped, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokens
+        def initialize: (?result_id: String, data: Array[Integer]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensClientCapabilities
+        def initialize: (?dynamic_registration: bool, requests: untyped, token_types: Array[String], token_modifiers: Array[String], formats: Array[untyped], ?overlapping_token_support: bool, ?multiline_token_support: bool, ?server_cancel_support: bool, ?augments_syntax_tokens: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_delta.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_delta.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensDelta
+        def initialize: (?result_id: String, edits: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_delta_params.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_delta_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensDeltaParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped, previous_result_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_delta_partial_result.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_delta_partial_result.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensDeltaPartialResult
+        def initialize: (edits: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_edit.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_edit.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensEdit
+        def initialize: (start: Integer, delete_count: Integer, ?data: Array[Integer]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_legend.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_legend.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensLegend
+        def initialize: (token_types: Array[String], token_modifiers: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_options.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensOptions
+        def initialize: (?work_done_progress: bool, legend: untyped, ?range: untyped, ?full: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_params.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_partial_result.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_partial_result.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensPartialResult
+        def initialize: (data: Array[Integer]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_range_params.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_range_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensRangeParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, text_document: untyped, range: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_registration_options.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, legend: untyped, ?range: untyped, ?full: untyped, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/semantic_tokens_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_workspace_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SemanticTokensWorkspaceClientCapabilities
+        def initialize: (?refresh_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/server_capabilities.rbs
+++ b/sig/language_server/protocol/interface/server_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ServerCapabilities
+        def initialize: (?position_encoding: String, ?text_document_sync: untyped, ?notebook_document_sync: untyped, ?completion_provider: untyped, ?hover_provider: untyped, ?signature_help_provider: untyped, ?declaration_provider: untyped, ?definition_provider: untyped, ?type_definition_provider: untyped, ?implementation_provider: untyped, ?references_provider: untyped, ?document_highlight_provider: untyped, ?document_symbol_provider: untyped, ?code_action_provider: untyped, ?code_lens_provider: untyped, ?document_link_provider: untyped, ?color_provider: untyped, ?document_formatting_provider: untyped, ?document_range_formatting_provider: untyped, ?document_on_type_formatting_provider: untyped, ?rename_provider: untyped, ?folding_range_provider: untyped, ?execute_command_provider: untyped, ?selection_range_provider: untyped, ?linked_editing_range_provider: untyped, ?call_hierarchy_provider: untyped, ?semantic_tokens_provider: untyped, ?moniker_provider: untyped, ?type_hierarchy_provider: untyped, ?inline_value_provider: untyped, ?inlay_hint_provider: untyped, ?diagnostic_provider: untyped, ?workspace_symbol_provider: untyped, ?workspace: untyped, ?experimental: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/set_trace_params.rbs
+++ b/sig/language_server/protocol/interface/set_trace_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SetTraceParams
+        def initialize: (value: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/show_document_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/show_document_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Client capabilities for the show document request.
+      #
+      class ShowDocumentClientCapabilities
+        def initialize: (support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/show_document_params.rbs
+++ b/sig/language_server/protocol/interface/show_document_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Params to show a resource.
+      #
+      class ShowDocumentParams
+        def initialize: (uri: String, ?external: bool, ?take_focus: bool, ?selection: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/show_document_result.rbs
+++ b/sig/language_server/protocol/interface/show_document_result.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The result of an show document request.
+      #
+      class ShowDocumentResult
+        def initialize: (success: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/show_message_params.rbs
+++ b/sig/language_server/protocol/interface/show_message_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ShowMessageParams
+        def initialize: (type: untyped, message: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/show_message_request_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/show_message_request_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Show message request client capabilities
+      #
+      class ShowMessageRequestClientCapabilities
+        def initialize: (?message_action_item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/show_message_request_params.rbs
+++ b/sig/language_server/protocol/interface/show_message_request_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class ShowMessageRequestParams
+        def initialize: (type: untyped, message: String, ?actions: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_help.rbs
+++ b/sig/language_server/protocol/interface/signature_help.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Signature help represents the signature of something
+      # callable. There can be multiple signature but only one
+      # active and only one active parameter.
+      #
+      class SignatureHelp
+        def initialize: (signatures: Array[untyped], ?active_signature: Integer, ?active_parameter: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_help_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/signature_help_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SignatureHelpClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?signature_information: untyped, ?context_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_help_context.rbs
+++ b/sig/language_server/protocol/interface/signature_help_context.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Additional information about the context in which a signature help request
+      # was triggered.
+      #
+      class SignatureHelpContext
+        def initialize: (trigger_kind: untyped, ?trigger_character: String, is_retrigger: bool, ?active_signature_help: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_help_options.rbs
+++ b/sig/language_server/protocol/interface/signature_help_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SignatureHelpOptions
+        def initialize: (?work_done_progress: bool, ?trigger_characters: Array[String], ?retrigger_characters: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_help_params.rbs
+++ b/sig/language_server/protocol/interface/signature_help_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SignatureHelpParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?context: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_help_registration_options.rbs
+++ b/sig/language_server/protocol/interface/signature_help_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class SignatureHelpRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?trigger_characters: Array[String], ?retrigger_characters: Array[String]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/signature_information.rbs
+++ b/sig/language_server/protocol/interface/signature_information.rbs
@@ -1,0 +1,21 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents the signature of something callable. A signature
+      # can have a label, like a function-name, a doc-comment, and
+      # a set of parameters.
+      #
+      class SignatureInformation
+        def initialize: (label: String, ?documentation: untyped, ?parameters: Array[untyped], ?active_parameter: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/static_registration_options.rbs
+++ b/sig/language_server/protocol/interface/static_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Static registration options to be returned in the initialize request.
+      #
+      class StaticRegistrationOptions
+        def initialize: (?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/symbol_information.rbs
+++ b/sig/language_server/protocol/interface/symbol_information.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Represents information about programming constructs like variables, classes,
+      # interfaces etc.
+      #
+      class SymbolInformation
+        def initialize: (name: String, kind: untyped, ?tags: Array[untyped], ?deprecated: bool, location: untyped, ?container_name: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_change_registration_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_change_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Describe options to be used when registering for text document change events.
+      #
+      class TextDocumentChangeRegistrationOptions
+        def initialize: (document_selector: untyped, sync_kind: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/text_document_client_capabilities.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Text document specific client capabilities.
+      #
+      class TextDocumentClientCapabilities
+        def initialize: (?synchronization: untyped, ?completion: untyped, ?hover: untyped, ?signature_help: untyped, ?declaration: untyped, ?definition: untyped, ?type_definition: untyped, ?implementation: untyped, ?references: untyped, ?document_highlight: untyped, ?document_symbol: untyped, ?code_action: untyped, ?code_lens: untyped, ?document_link: untyped, ?color_provider: untyped, ?formatting: untyped, ?range_formatting: untyped, ?on_type_formatting: untyped, ?rename: untyped, ?publish_diagnostics: untyped, ?folding_range: untyped, ?selection_range: untyped, ?linked_editing_range: untyped, ?call_hierarchy: untyped, ?semantic_tokens: untyped, ?moniker: untyped, ?type_hierarchy: untyped, ?inline_value: untyped, ?inlay_hint: untyped, ?diagnostic: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_content_change_event.rbs
+++ b/sig/language_server/protocol/interface/text_document_content_change_event.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # An event describing a change to a text document. If only a text is provided
+      # it is considered to be the full content of the document.
+      #
+      class TextDocumentContentChangeEvent
+        def initialize: (?range: untyped?, ?range_length: Integer?, text: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_edit.rbs
+++ b/sig/language_server/protocol/interface/text_document_edit.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentEdit
+        def initialize: (text_document: untyped, edits: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/text_document_identifier.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentIdentifier
+        def initialize: (uri: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_item.rbs
+++ b/sig/language_server/protocol/interface/text_document_item.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentItem
+        def initialize: (uri: String, language_id: String, version: Integer, text: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_position_params.rbs
+++ b/sig/language_server/protocol/interface/text_document_position_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentPositionParams
+        def initialize: (text_document: untyped, position: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_registration_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_registration_options.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # General text document registration options.
+      #
+      class TextDocumentRegistrationOptions
+        def initialize: (document_selector: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_save_registration_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_save_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentSaveRegistrationOptions
+        def initialize: (document_selector: untyped, ?include_text: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_sync_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/text_document_sync_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentSyncClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?will_save: bool, ?will_save_wait_until: bool, ?did_save: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_document_sync_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_sync_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextDocumentSyncOptions
+        def initialize: (?open_close: bool, ?change: untyped, ?will_save: bool, ?will_save_wait_until: bool, ?save: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/text_edit.rbs
+++ b/sig/language_server/protocol/interface/text_edit.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TextEdit
+        def initialize: (range: untyped, new_text: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_definition_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/type_definition_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeDefinitionClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?link_support: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_definition_options.rbs
+++ b/sig/language_server/protocol/interface/type_definition_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeDefinitionOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_definition_params.rbs
+++ b/sig/language_server/protocol/interface/type_definition_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeDefinitionParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped, ?partial_result_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_definition_registration_options.rbs
+++ b/sig/language_server/protocol/interface/type_definition_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeDefinitionRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_hierarchy_item.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_item.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeHierarchyItem
+        def initialize: (name: String, kind: untyped, ?tags: Array[untyped], ?detail: String, uri: String, range: untyped, selection_range: untyped, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_hierarchy_options.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeHierarchyOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_hierarchy_prepare_params.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_prepare_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeHierarchyPrepareParams
+        def initialize: (text_document: untyped, position: untyped, ?work_done_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_hierarchy_registration_options.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeHierarchyRegistrationOptions
+        def initialize: (document_selector: untyped, ?work_done_progress: bool, ?id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_hierarchy_subtypes_params.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_subtypes_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeHierarchySubtypesParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/type_hierarchy_supertypes_params.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_supertypes_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class TypeHierarchySupertypesParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, item: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/unchanged_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/unchanged_document_diagnostic_report.rbs
@@ -1,0 +1,20 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A diagnostic report indicating that the last returned
+      # report is still accurate.
+      #
+      class UnchangedDocumentDiagnosticReport
+        def initialize: (kind: untyped, result_id: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/unregistration.rbs
+++ b/sig/language_server/protocol/interface/unregistration.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # General parameters to unregister a capability.
+      #
+      class Unregistration
+        def initialize: (id: String, method: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/unregistration_params.rbs
+++ b/sig/language_server/protocol/interface/unregistration_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class UnregistrationParams
+        def initialize: (unregisterations: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/versioned_notebook_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/versioned_notebook_document_identifier.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A versioned notebook document identifier.
+      #
+      class VersionedNotebookDocumentIdentifier
+        def initialize: (version: Integer, uri: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/versioned_text_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/versioned_text_document_identifier.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class VersionedTextDocumentIdentifier
+        def initialize: (uri: String, version: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/will_save_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/will_save_text_document_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The parameters send in a will save text document notification.
+      #
+      class WillSaveTextDocumentParams
+        def initialize: (text_document: untyped, reason: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_begin.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_begin.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressBegin
+        def initialize: (kind: untyped, title: String, ?cancellable: bool, ?message: String, ?percentage: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_cancel_params.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_cancel_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressCancelParams
+        def initialize: (token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_create_params.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_create_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressCreateParams
+        def initialize: (token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_end.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_end.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressEnd
+        def initialize: (kind: untyped, ?message: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_options.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressOptions
+        def initialize: (?work_done_progress: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_params.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_params.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressParams
+        def initialize: (?work_done_token: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/work_done_progress_report.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_report.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkDoneProgressReport
+        def initialize: (kind: untyped, ?cancellable: bool, ?message: String, ?percentage: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_diagnostic_params.rbs
+++ b/sig/language_server/protocol/interface/workspace_diagnostic_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # Parameters of the workspace diagnostic request.
+      #
+      class WorkspaceDiagnosticParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, ?identifier: String, previous_result_ids: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/workspace_diagnostic_report.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A workspace diagnostic report.
+      #
+      class WorkspaceDiagnosticReport
+        def initialize: (items: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_diagnostic_report_partial_result.rbs
+++ b/sig/language_server/protocol/interface/workspace_diagnostic_report_partial_result.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A partial result for a workspace diagnostic report.
+      #
+      class WorkspaceDiagnosticReportPartialResult
+        def initialize: (items: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_edit.rbs
+++ b/sig/language_server/protocol/interface/workspace_edit.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceEdit
+        def initialize: (?changes: untyped, ?document_changes: Array[untyped], ?change_annotations: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_edit_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/workspace_edit_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceEditClientCapabilities
+        def initialize: (?document_changes: bool, ?resource_operations: Array[untyped], ?failure_handling: untyped, ?normalizes_line_endings: bool, ?change_annotation_support: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_folder.rbs
+++ b/sig/language_server/protocol/interface/workspace_folder.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceFolder
+        def initialize: (uri: String, name: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_folders_change_event.rbs
+++ b/sig/language_server/protocol/interface/workspace_folders_change_event.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The workspace folder change event.
+      #
+      class WorkspaceFoldersChangeEvent
+        def initialize: (added: Array[untyped], removed: Array[untyped]) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_folders_server_capabilities.rbs
+++ b/sig/language_server/protocol/interface/workspace_folders_server_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceFoldersServerCapabilities
+        def initialize: (?supported: bool, ?change_notifications: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_full_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/workspace_full_document_diagnostic_report.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A full document diagnostic report for a workspace diagnostic result.
+      #
+      class WorkspaceFullDocumentDiagnosticReport
+        def initialize: (kind: untyped, ?result_id: String, items: Array[untyped], uri: String, version: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_symbol.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # A special workspace symbol that supports locations without a range
+      #
+      class WorkspaceSymbol
+        def initialize: (name: String, kind: untyped, ?tags: Array[untyped], ?container_name: String, location: untyped, ?data: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_symbol_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_client_capabilities.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceSymbolClientCapabilities
+        def initialize: (?dynamic_registration: bool, ?symbol_kind: untyped, ?tag_support: untyped, ?resolve_support: untyped) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_symbol_options.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceSymbolOptions
+        def initialize: (?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_symbol_params.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_params.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # The parameters of a Workspace Symbol Request.
+      #
+      class WorkspaceSymbolParams
+        def initialize: (?work_done_token: untyped, ?partial_result_token: untyped, query: String) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_symbol_registration_options.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_registration_options.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      class WorkspaceSymbolRegistrationOptions
+        def initialize: (?work_done_progress: bool, ?resolve_provider: bool) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/interface/workspace_unchanged_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/workspace_unchanged_document_diagnostic_report.rbs
@@ -1,0 +1,19 @@
+module LanguageServer
+  module Protocol
+    module Interface
+      #
+      # An unchanged document diagnostic report for a workspace diagnostic result.
+      #
+      class WorkspaceUnchangedDocumentDiagnosticReport
+        def initialize: (kind: untyped, result_id: String, uri: String, version: Integer) -> void
+
+        @attributes: Hash[Symbol, untyped]
+        attr_reader attributes: Hash[Symbol, untyped]
+
+        def to_hash: () -> Hash[Symbol, untyped]
+
+        def to_json: (*untyped) -> String
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/transport/io/reader.rbs
+++ b/sig/language_server/protocol/transport/io/reader.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Transport
+      module Io
+        class Reader
+          @io: IO
+          attr_reader io: IO
+
+          def initialize: (IO) -> void
+
+          def read: () { (untyped) -> untyped } -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/language_server/protocol/transport/io/writer.rbs
+++ b/sig/language_server/protocol/transport/io/writer.rbs
@@ -1,0 +1,16 @@
+module LanguageServer
+  module Protocol
+    module Transport
+      module Io
+        class Writer
+          @io: IO
+          attr_reader io: IO
+
+          def initialize: (IO) -> void
+
+          def write: (untyped) -> void
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request add rbs signatures for generated files.

Union type and type alias are not supported currently. I handle them as `untyped` now.

nevertheless, These signatures are useful for type checking and code completion.

I also write Steepfile to enable type checking.
But, I met a mysterious `DuplicatedDeclarationError`.
Because I couldn't resolve this, some type-checking errors are left.