### PR TITLE
Probably this change fixes the forked repo problem

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: true
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.PAT || github.token }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"


### PR DESCRIPTION
```
Error: Input required and not supplied: token
```

https://github.com/mtsmfm/language_server-protocol-ruby/actions/runs/9206138728/job/25323647999