### PR TITLE
Add `#close` to Reader and Writer

### DIFF
--- a/lib/language_server/protocol/transport/io/reader.rb
+++ b/lib/language_server/protocol/transport/io/reader.rb
@@ -21,6 +21,10 @@ module LanguageServer
             end
           end
 
+          def close
+            io.close
+          end
+
           private
 
           attr_reader :io

--- a/lib/language_server/protocol/transport/io/writer.rb
+++ b/lib/language_server/protocol/transport/io/writer.rb
@@ -28,6 +28,10 @@ module LanguageServer
             io.print response_str
             io.flush
           end
+
+          def close
+            io.close
+          end
         end
       end
     end


### PR DESCRIPTION
This PR adds `close` methods to `LanguageServer::Protocol::Transport::Io::Reader` and `LanguageServer::Protocol::Transport::Io::Reader`.


I'm working on Steep to introduce a new feature. I need to stop the LSP server in the feature, but this library does not expose `close` methods. So it can't treat the IO correctly.


This PR exposes `close` method to solve this problem.


