### PR TITLE
Generate RBS signatures of attribute method signatures

### DIFF
--- a/sig/language_server/protocol/interface/annotated_text_edit.rbs
+++ b/sig/language_server/protocol/interface/annotated_text_edit.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def new_text: () -> String
+
+        %a{pure}
+        def annotation_id: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/apply_workspace_edit_params.rbs
+++ b/sig/language_server/protocol/interface/apply_workspace_edit_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def label: () -> String?
+
+        %a{pure}
+        def edit: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/apply_workspace_edit_result.rbs
+++ b/sig/language_server/protocol/interface/apply_workspace_edit_result.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def applied: () -> bool
+
+        %a{pure}
+        def failure_reason: () -> String?
+
+        %a{pure}
+        def failed_change: () -> Integer?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_incoming_call.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_incoming_call.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def from: () -> untyped
+
+        %a{pure}
+        def from_ranges: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_incoming_calls_params.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_incoming_calls_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_item.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_item.rbs
@@ -7,6 +7,30 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def name: () -> String
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def detail: () -> String?
+
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def selection_range: () -> untyped
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_options.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_outgoing_call.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_outgoing_call.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def to: () -> untyped
+
+        %a{pure}
+        def from_ranges: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_outgoing_calls_params.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_outgoing_calls_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_prepare_params.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_prepare_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/call_hierarchy_registration_options.rbs
+++ b/sig/language_server/protocol/interface/call_hierarchy_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/cancel_params.rbs
+++ b/sig/language_server/protocol/interface/cancel_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def id: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/change_annotation.rbs
+++ b/sig/language_server/protocol/interface/change_annotation.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def label: () -> String
+
+        %a{pure}
+        def needs_confirmation: () -> bool?
+
+        %a{pure}
+        def description: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/client_capabilities.rbs
@@ -7,6 +7,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def workspace: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def notebook_document: () -> untyped
+
+        %a{pure}
+        def window: () -> untyped
+
+        %a{pure}
+        def general: () -> untyped
+
+        %a{pure}
+        def experimental: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_action.rbs
+++ b/sig/language_server/protocol/interface/code_action.rbs
@@ -14,6 +14,30 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def title: () -> String
+
+        %a{pure}
+        def kind: () -> String?
+
+        %a{pure}
+        def diagnostics: () -> Array[untyped]?
+
+        %a{pure}
+        def is_preferred: () -> bool?
+
+        %a{pure}
+        def disabled: () -> untyped
+
+        %a{pure}
+        def edit: () -> untyped
+
+        %a{pure}
+        def command: () -> untyped
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_action_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/code_action_client_capabilities.rbs
@@ -7,6 +7,27 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def code_action_literal_support: () -> untyped
+
+        %a{pure}
+        def is_preferred_support: () -> bool?
+
+        %a{pure}
+        def disabled_support: () -> bool?
+
+        %a{pure}
+        def data_support: () -> bool?
+
+        %a{pure}
+        def resolve_support: () -> untyped
+
+        %a{pure}
+        def honors_change_annotations: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_action_context.rbs
+++ b/sig/language_server/protocol/interface/code_action_context.rbs
@@ -11,6 +11,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def diagnostics: () -> Array[untyped]
+
+        %a{pure}
+        def only: () -> Array[String]?
+
+        %a{pure}
+        def trigger_kind: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_action_options.rbs
+++ b/sig/language_server/protocol/interface/code_action_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def code_action_kinds: () -> Array[String]?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_action_params.rbs
+++ b/sig/language_server/protocol/interface/code_action_params.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def context: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_action_registration_options.rbs
+++ b/sig/language_server/protocol/interface/code_action_registration_options.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def code_action_kinds: () -> Array[String]?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_description.rbs
+++ b/sig/language_server/protocol/interface/code_description.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def href: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_lens.rbs
+++ b/sig/language_server/protocol/interface/code_lens.rbs
@@ -15,6 +15,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def command: () -> untyped
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_lens_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/code_lens_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_lens_options.rbs
+++ b/sig/language_server/protocol/interface/code_lens_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_lens_params.rbs
+++ b/sig/language_server/protocol/interface/code_lens_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_lens_registration_options.rbs
+++ b/sig/language_server/protocol/interface/code_lens_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/code_lens_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/code_lens_workspace_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def refresh_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/color.rbs
+++ b/sig/language_server/protocol/interface/color.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def red: () -> Integer
+
+        %a{pure}
+        def green: () -> Integer
+
+        %a{pure}
+        def blue: () -> Integer
+
+        %a{pure}
+        def alpha: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/color_information.rbs
+++ b/sig/language_server/protocol/interface/color_information.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def color: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/color_presentation.rbs
+++ b/sig/language_server/protocol/interface/color_presentation.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def label: () -> String
+
+        %a{pure}
+        def text_edit: () -> untyped
+
+        %a{pure}
+        def additional_text_edits: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/color_presentation_params.rbs
+++ b/sig/language_server/protocol/interface/color_presentation_params.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def color: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/command.rbs
+++ b/sig/language_server/protocol/interface/command.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def title: () -> String
+
+        %a{pure}
+        def command: () -> String
+
+        %a{pure}
+        def arguments: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/completion_client_capabilities.rbs
@@ -7,6 +7,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def completion_item: () -> untyped
+
+        %a{pure}
+        def completion_item_kind: () -> untyped
+
+        %a{pure}
+        def context_support: () -> bool?
+
+        %a{pure}
+        def insert_text_mode: () -> untyped
+
+        %a{pure}
+        def completion_list: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_context.rbs
+++ b/sig/language_server/protocol/interface/completion_context.rbs
@@ -11,6 +11,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def trigger_kind: () -> untyped
+
+        %a{pure}
+        def trigger_character: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_item.rbs
+++ b/sig/language_server/protocol/interface/completion_item.rbs
@@ -7,6 +7,63 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def label: () -> String
+
+        %a{pure}
+        def label_details: () -> untyped
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def detail: () -> String?
+
+        %a{pure}
+        def documentation: () -> untyped
+
+        %a{pure}
+        def deprecated: () -> bool?
+
+        %a{pure}
+        def preselect: () -> bool?
+
+        %a{pure}
+        def sort_text: () -> String?
+
+        %a{pure}
+        def filter_text: () -> String?
+
+        %a{pure}
+        def insert_text: () -> String?
+
+        %a{pure}
+        def insert_text_format: () -> untyped
+
+        %a{pure}
+        def insert_text_mode: () -> untyped
+
+        %a{pure}
+        def text_edit: () -> untyped
+
+        %a{pure}
+        def text_edit_text: () -> String?
+
+        %a{pure}
+        def additional_text_edits: () -> Array[untyped]?
+
+        %a{pure}
+        def commit_characters: () -> Array[String]?
+
+        %a{pure}
+        def command: () -> untyped
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_item_label_details.rbs
+++ b/sig/language_server/protocol/interface/completion_item_label_details.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def detail: () -> String?
+
+        %a{pure}
+        def description: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_list.rbs
+++ b/sig/language_server/protocol/interface/completion_list.rbs
@@ -11,6 +11,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def is_incomplete: () -> bool
+
+        %a{pure}
+        def item_defaults: () -> untyped
+
+        %a{pure}
+        def items: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_options.rbs
+++ b/sig/language_server/protocol/interface/completion_options.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def trigger_characters: () -> Array[String]?
+
+        %a{pure}
+        def all_commit_characters: () -> Array[String]?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
+        %a{pure}
+        def completion_item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_params.rbs
+++ b/sig/language_server/protocol/interface/completion_params.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def context: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/completion_registration_options.rbs
+++ b/sig/language_server/protocol/interface/completion_registration_options.rbs
@@ -7,6 +7,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def trigger_characters: () -> Array[String]?
+
+        %a{pure}
+        def all_commit_characters: () -> Array[String]?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
+        %a{pure}
+        def completion_item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/configuration_item.rbs
+++ b/sig/language_server/protocol/interface/configuration_item.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def scope_uri: () -> String?
+
+        %a{pure}
+        def section: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/configuration_params.rbs
+++ b/sig/language_server/protocol/interface/configuration_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def items: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/create_file.rbs
+++ b/sig/language_server/protocol/interface/create_file.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def options: () -> untyped
+
+        %a{pure}
+        def annotation_id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/create_file_options.rbs
+++ b/sig/language_server/protocol/interface/create_file_options.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def overwrite: () -> bool?
+
+        %a{pure}
+        def ignore_if_exists: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/create_files_params.rbs
+++ b/sig/language_server/protocol/interface/create_files_params.rbs
@@ -11,6 +11,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def files: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/declaration_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/declaration_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def link_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/declaration_options.rbs
+++ b/sig/language_server/protocol/interface/declaration_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/declaration_params.rbs
+++ b/sig/language_server/protocol/interface/declaration_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/declaration_registration_options.rbs
+++ b/sig/language_server/protocol/interface/declaration_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/definition_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/definition_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def link_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/definition_options.rbs
+++ b/sig/language_server/protocol/interface/definition_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/definition_params.rbs
+++ b/sig/language_server/protocol/interface/definition_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/definition_registration_options.rbs
+++ b/sig/language_server/protocol/interface/definition_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/delete_file.rbs
+++ b/sig/language_server/protocol/interface/delete_file.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def options: () -> untyped
+
+        %a{pure}
+        def annotation_id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/delete_file_options.rbs
+++ b/sig/language_server/protocol/interface/delete_file_options.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def recursive: () -> bool?
+
+        %a{pure}
+        def ignore_if_not_exists: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/delete_files_params.rbs
+++ b/sig/language_server/protocol/interface/delete_files_params.rbs
@@ -11,6 +11,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def files: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic.rbs
+++ b/sig/language_server/protocol/interface/diagnostic.rbs
@@ -7,6 +7,33 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def severity: () -> untyped
+
+        %a{pure}
+        def code: () -> untyped
+
+        %a{pure}
+        def code_description: () -> untyped
+
+        %a{pure}
+        def source: () -> String?
+
+        %a{pure}
+        def message: () -> String
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def related_information: () -> Array[untyped]?
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_client_capabilities.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def related_document_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic_options.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_options.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def identifier: () -> String?
+
+        %a{pure}
+        def inter_file_dependencies: () -> bool
+
+        %a{pure}
+        def workspace_diagnostics: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic_registration_options.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_registration_options.rbs
@@ -10,6 +10,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def identifier: () -> String?
+
+        %a{pure}
+        def inter_file_dependencies: () -> bool
+
+        %a{pure}
+        def workspace_diagnostics: () -> bool
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic_related_information.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_related_information.rbs
@@ -12,6 +12,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def location: () -> untyped
+
+        %a{pure}
+        def message: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic_server_cancellation_data.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_server_cancellation_data.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def retrigger_request: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/diagnostic_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/diagnostic_workspace_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def refresh_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_configuration_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/did_change_configuration_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_configuration_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_configuration_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def settings: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_notebook_document_params.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_document: () -> untyped
+
+        %a{pure}
+        def change: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_text_document_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def content_changes: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_watched_files_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/did_change_watched_files_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def relative_pattern_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_watched_files_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_watched_files_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def changes: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_watched_files_registration_options.rbs
+++ b/sig/language_server/protocol/interface/did_change_watched_files_registration_options.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def watchers: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_change_workspace_folders_params.rbs
+++ b/sig/language_server/protocol/interface/did_change_workspace_folders_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def event: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_close_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_close_notebook_document_params.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_document: () -> untyped
+
+        %a{pure}
+        def cell_text_documents: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_close_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_close_text_document_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_open_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_open_notebook_document_params.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_document: () -> untyped
+
+        %a{pure}
+        def cell_text_documents: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_open_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_open_text_document_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_save_notebook_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_save_notebook_document_params.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/did_save_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/did_save_text_document_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def text: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_color_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_color_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_color_options.rbs
+++ b/sig/language_server/protocol/interface/document_color_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_color_params.rbs
+++ b/sig/language_server/protocol/interface/document_color_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_color_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_color_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def id: () -> String?
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_diagnostic_params.rbs
+++ b/sig/language_server/protocol/interface/document_diagnostic_params.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def identifier: () -> String?
+
+        %a{pure}
+        def previous_result_id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_diagnostic_report_partial_result.rbs
+++ b/sig/language_server/protocol/interface/document_diagnostic_report_partial_result.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def related_documents: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_filter.rbs
+++ b/sig/language_server/protocol/interface/document_filter.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def language: () -> String?
+
+        %a{pure}
+        def scheme: () -> String?
+
+        %a{pure}
+        def pattern: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_formatting_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_formatting_options.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_formatting_params.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def options: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_formatting_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_formatting_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_highlight.rbs
+++ b/sig/language_server/protocol/interface/document_highlight.rbs
@@ -12,6 +12,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def kind: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_highlight_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_highlight_options.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_highlight_params.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_highlight_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_highlight_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_link.rbs
+++ b/sig/language_server/protocol/interface/document_link.rbs
@@ -11,6 +11,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def target: () -> String?
+
+        %a{pure}
+        def tooltip: () -> String?
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_link_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_link_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def tooltip_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_link_options.rbs
+++ b/sig/language_server/protocol/interface/document_link_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_link_params.rbs
+++ b/sig/language_server/protocol/interface/document_link_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_link_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_link_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_on_type_formatting_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_on_type_formatting_options.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def first_trigger_character: () -> String
+
+        %a{pure}
+        def more_trigger_character: () -> Array[String]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_on_type_formatting_params.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def ch: () -> String
+
+        %a{pure}
+        def options: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_on_type_formatting_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_on_type_formatting_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def first_trigger_character: () -> String
+
+        %a{pure}
+        def more_trigger_character: () -> Array[String]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_range_formatting_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_range_formatting_options.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_range_formatting_params.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def options: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_range_formatting_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_range_formatting_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_symbol.rbs
+++ b/sig/language_server/protocol/interface/document_symbol.rbs
@@ -13,6 +13,30 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def name: () -> String
+
+        %a{pure}
+        def detail: () -> String?
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def deprecated: () -> bool?
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def selection_range: () -> untyped
+
+        %a{pure}
+        def children: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_symbol_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_client_capabilities.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def symbol_kind: () -> untyped
+
+        %a{pure}
+        def hierarchical_document_symbol_support: () -> bool?
+
+        %a{pure}
+        def tag_support: () -> untyped
+
+        %a{pure}
+        def label_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_symbol_options.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def label: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_symbol_params.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/document_symbol_registration_options.rbs
+++ b/sig/language_server/protocol/interface/document_symbol_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def label: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/execute_command_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/execute_command_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/execute_command_options.rbs
+++ b/sig/language_server/protocol/interface/execute_command_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def commands: () -> Array[String]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/execute_command_params.rbs
+++ b/sig/language_server/protocol/interface/execute_command_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def command: () -> String
+
+        %a{pure}
+        def arguments: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/execute_command_registration_options.rbs
+++ b/sig/language_server/protocol/interface/execute_command_registration_options.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def commands: () -> Array[String]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/execution_summary.rbs
+++ b/sig/language_server/protocol/interface/execution_summary.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def execution_order: () -> Integer
+
+        %a{pure}
+        def success: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_create.rbs
+++ b/sig/language_server/protocol/interface/file_create.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_delete.rbs
+++ b/sig/language_server/protocol/interface/file_delete.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_event.rbs
+++ b/sig/language_server/protocol/interface/file_event.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def type: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_operation_filter.rbs
+++ b/sig/language_server/protocol/interface/file_operation_filter.rbs
@@ -11,6 +11,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def scheme: () -> String?
+
+        %a{pure}
+        def pattern: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_operation_pattern.rbs
+++ b/sig/language_server/protocol/interface/file_operation_pattern.rbs
@@ -11,6 +11,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def glob: () -> String
+
+        %a{pure}
+        def matches: () -> untyped
+
+        %a{pure}
+        def options: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_operation_pattern_options.rbs
+++ b/sig/language_server/protocol/interface/file_operation_pattern_options.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def ignore_case: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_operation_registration_options.rbs
+++ b/sig/language_server/protocol/interface/file_operation_registration_options.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def filters: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_rename.rbs
+++ b/sig/language_server/protocol/interface/file_rename.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def old_uri: () -> String
+
+        %a{pure}
+        def new_uri: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/file_system_watcher.rbs
+++ b/sig/language_server/protocol/interface/file_system_watcher.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def glob_pattern: () -> untyped
+
+        %a{pure}
+        def kind: () -> Integer?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/folding_range.rbs
+++ b/sig/language_server/protocol/interface/folding_range.rbs
@@ -12,6 +12,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def start_line: () -> Integer
+
+        %a{pure}
+        def start_character: () -> Integer?
+
+        %a{pure}
+        def end_line: () -> Integer
+
+        %a{pure}
+        def end_character: () -> Integer?
+
+        %a{pure}
+        def kind: () -> String?
+
+        %a{pure}
+        def collapsed_text: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/folding_range_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/folding_range_client_capabilities.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def range_limit: () -> Integer?
+
+        %a{pure}
+        def line_folding_only: () -> bool?
+
+        %a{pure}
+        def folding_range_kind: () -> untyped
+
+        %a{pure}
+        def folding_range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/folding_range_options.rbs
+++ b/sig/language_server/protocol/interface/folding_range_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/folding_range_params.rbs
+++ b/sig/language_server/protocol/interface/folding_range_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/folding_range_registration_options.rbs
+++ b/sig/language_server/protocol/interface/folding_range_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/formatting_options.rbs
+++ b/sig/language_server/protocol/interface/formatting_options.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def tab_size: () -> Integer
+
+        %a{pure}
+        def insert_spaces: () -> bool
+
+        %a{pure}
+        def trim_trailing_whitespace: () -> bool?
+
+        %a{pure}
+        def insert_final_newline: () -> bool?
+
+        %a{pure}
+        def trim_final_newlines: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/full_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/full_document_diagnostic_report.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def result_id: () -> String?
+
+        %a{pure}
+        def items: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/hover.rbs
+++ b/sig/language_server/protocol/interface/hover.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def contents: () -> Array[untyped]
+
+        %a{pure}
+        def range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/hover_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/hover_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def content_format: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/hover_options.rbs
+++ b/sig/language_server/protocol/interface/hover_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/hover_params.rbs
+++ b/sig/language_server/protocol/interface/hover_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/hover_registration_options.rbs
+++ b/sig/language_server/protocol/interface/hover_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/hover_result.rbs
+++ b/sig/language_server/protocol/interface/hover_result.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def value: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/implementation_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/implementation_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def link_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/implementation_options.rbs
+++ b/sig/language_server/protocol/interface/implementation_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/implementation_params.rbs
+++ b/sig/language_server/protocol/interface/implementation_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/implementation_registration_options.rbs
+++ b/sig/language_server/protocol/interface/implementation_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/initialize_error.rbs
+++ b/sig/language_server/protocol/interface/initialize_error.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def retry: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/initialize_params.rbs
+++ b/sig/language_server/protocol/interface/initialize_params.rbs
@@ -7,6 +7,36 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def process_id: () -> Integer
+
+        %a{pure}
+        def client_info: () -> untyped
+
+        %a{pure}
+        def locale: () -> String?
+
+        %a{pure}
+        def root_path: () -> String?
+
+        %a{pure}
+        def root_uri: () -> String
+
+        %a{pure}
+        def initialization_options: () -> untyped
+
+        %a{pure}
+        def capabilities: () -> untyped
+
+        %a{pure}
+        def trace: () -> untyped
+
+        %a{pure}
+        def workspace_folders: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/initialize_result.rbs
+++ b/sig/language_server/protocol/interface/initialize_result.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def capabilities: () -> untyped
+
+        %a{pure}
+        def server_info: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint.rbs
@@ -10,6 +10,30 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def label: () -> Array[untyped]
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def text_edits: () -> Array[untyped]?
+
+        %a{pure}
+        def tooltip: () -> untyped
+
+        %a{pure}
+        def padding_left: () -> bool?
+
+        %a{pure}
+        def padding_right: () -> bool?
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_client_capabilities.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def resolve_support: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint_label_part.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_label_part.rbs
@@ -11,6 +11,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def value: () -> String
+
+        %a{pure}
+        def tooltip: () -> untyped
+
+        %a{pure}
+        def location: () -> untyped
+
+        %a{pure}
+        def command: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint_options.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_options.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint_params.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_params.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint_registration_options.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_registration_options.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inlay_hint_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inlay_hint_workspace_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def refresh_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inline_value_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_context.rbs
+++ b/sig/language_server/protocol/interface/inline_value_context.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def frame_id: () -> Integer
+
+        %a{pure}
+        def stopped_location: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_evaluatable_expression.rbs
+++ b/sig/language_server/protocol/interface/inline_value_evaluatable_expression.rbs
@@ -15,6 +15,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def expression: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_options.rbs
+++ b/sig/language_server/protocol/interface/inline_value_options.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_params.rbs
+++ b/sig/language_server/protocol/interface/inline_value_params.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def context: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_registration_options.rbs
+++ b/sig/language_server/protocol/interface/inline_value_registration_options.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_text.rbs
+++ b/sig/language_server/protocol/interface/inline_value_text.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def text: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_variable_lookup.rbs
+++ b/sig/language_server/protocol/interface/inline_value_variable_lookup.rbs
@@ -15,6 +15,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def variable_name: () -> String?
+
+        %a{pure}
+        def case_sensitive_lookup: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/inline_value_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/inline_value_workspace_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def refresh_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/insert_replace_edit.rbs
+++ b/sig/language_server/protocol/interface/insert_replace_edit.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def new_text: () -> String
+
+        %a{pure}
+        def insert: () -> untyped
+
+        %a{pure}
+        def replace: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/linked_editing_range_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/linked_editing_range_options.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/linked_editing_range_params.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/linked_editing_range_registration_options.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_range_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/linked_editing_ranges.rbs
+++ b/sig/language_server/protocol/interface/linked_editing_ranges.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def ranges: () -> Array[untyped]
+
+        %a{pure}
+        def word_pattern: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/location.rbs
+++ b/sig/language_server/protocol/interface/location.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/location_link.rbs
+++ b/sig/language_server/protocol/interface/location_link.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def origin_selection_range: () -> untyped
+
+        %a{pure}
+        def target_uri: () -> String
+
+        %a{pure}
+        def target_range: () -> untyped
+
+        %a{pure}
+        def target_selection_range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/log_message_params.rbs
+++ b/sig/language_server/protocol/interface/log_message_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def type: () -> untyped
+
+        %a{pure}
+        def message: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/log_trace_params.rbs
+++ b/sig/language_server/protocol/interface/log_trace_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def message: () -> String
+
+        %a{pure}
+        def verbose: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/markup_content.rbs
+++ b/sig/language_server/protocol/interface/markup_content.rbs
@@ -33,6 +33,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def value: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/message.rbs
+++ b/sig/language_server/protocol/interface/message.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def jsonrpc: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/message_action_item.rbs
+++ b/sig/language_server/protocol/interface/message_action_item.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def title: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/moniker.rbs
+++ b/sig/language_server/protocol/interface/moniker.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def scheme: () -> String
+
+        %a{pure}
+        def identifier: () -> String
+
+        %a{pure}
+        def unique: () -> untyped
+
+        %a{pure}
+        def kind: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/moniker_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/moniker_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/moniker_options.rbs
+++ b/sig/language_server/protocol/interface/moniker_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/moniker_params.rbs
+++ b/sig/language_server/protocol/interface/moniker_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/moniker_registration_options.rbs
+++ b/sig/language_server/protocol/interface/moniker_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_cell.rbs
+++ b/sig/language_server/protocol/interface/notebook_cell.rbs
@@ -14,6 +14,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def document: () -> String
+
+        %a{pure}
+        def metadata: () -> untyped
+
+        %a{pure}
+        def execution_summary: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_cell_array_change.rbs
+++ b/sig/language_server/protocol/interface/notebook_cell_array_change.rbs
@@ -11,6 +11,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def start: () -> Integer
+
+        %a{pure}
+        def delete_count: () -> Integer
+
+        %a{pure}
+        def cells: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_cell_text_document_filter.rbs
+++ b/sig/language_server/protocol/interface/notebook_cell_text_document_filter.rbs
@@ -11,6 +11,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook: () -> untyped
+
+        %a{pure}
+        def language: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document.rbs
+++ b/sig/language_server/protocol/interface/notebook_document.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def notebook_type: () -> String
+
+        %a{pure}
+        def version: () -> Integer
+
+        %a{pure}
+        def metadata: () -> untyped
+
+        %a{pure}
+        def cells: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_change_event.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_change_event.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def metadata: () -> untyped
+
+        %a{pure}
+        def cells: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def synchronization: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_filter.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_filter.rbs
@@ -11,6 +11,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_type: () -> String?
+
+        %a{pure}
+        def scheme: () -> String?
+
+        %a{pure}
+        def pattern: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_identifier.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_sync_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_sync_client_capabilities.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def execution_summary_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_sync_options.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_sync_options.rbs
@@ -20,6 +20,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_selector: () -> Array[untyped]
+
+        %a{pure}
+        def save: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notebook_document_sync_registration_options.rbs
+++ b/sig/language_server/protocol/interface/notebook_document_sync_registration_options.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def notebook_selector: () -> Array[untyped]
+
+        %a{pure}
+        def save: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/notification_message.rbs
+++ b/sig/language_server/protocol/interface/notification_message.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def jsonrpc: () -> String
+
+        %a{pure}
+        def method: () -> String
+
+        %a{pure}
+        def params: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/optional_versioned_text_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/optional_versioned_text_document_identifier.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def version: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/parameter_information.rbs
+++ b/sig/language_server/protocol/interface/parameter_information.rbs
@@ -11,6 +11,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def label: () -> untyped
+
+        %a{pure}
+        def documentation: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/partial_result_params.rbs
+++ b/sig/language_server/protocol/interface/partial_result_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/position.rbs
+++ b/sig/language_server/protocol/interface/position.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def line: () -> Integer
+
+        %a{pure}
+        def character: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/prepare_rename_params.rbs
+++ b/sig/language_server/protocol/interface/prepare_rename_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/previous_result_id.rbs
+++ b/sig/language_server/protocol/interface/previous_result_id.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def value: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/progress_params.rbs
+++ b/sig/language_server/protocol/interface/progress_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def token: () -> untyped
+
+        %a{pure}
+        def value: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/publish_diagnostics_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/publish_diagnostics_client_capabilities.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def related_information: () -> bool?
+
+        %a{pure}
+        def tag_support: () -> untyped
+
+        %a{pure}
+        def version_support: () -> bool?
+
+        %a{pure}
+        def code_description_support: () -> bool?
+
+        %a{pure}
+        def data_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/publish_diagnostics_params.rbs
+++ b/sig/language_server/protocol/interface/publish_diagnostics_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def version: () -> Integer?
+
+        %a{pure}
+        def diagnostics: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/range.rbs
+++ b/sig/language_server/protocol/interface/range.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def start: () -> untyped
+
+        %a{pure}
+        def end: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/reference_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/reference_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/reference_context.rbs
+++ b/sig/language_server/protocol/interface/reference_context.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def include_declaration: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/reference_options.rbs
+++ b/sig/language_server/protocol/interface/reference_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/reference_params.rbs
+++ b/sig/language_server/protocol/interface/reference_params.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def context: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/reference_registration_options.rbs
+++ b/sig/language_server/protocol/interface/reference_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/registration.rbs
+++ b/sig/language_server/protocol/interface/registration.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def id: () -> String
+
+        %a{pure}
+        def method: () -> String
+
+        %a{pure}
+        def register_options: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/registration_params.rbs
+++ b/sig/language_server/protocol/interface/registration_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def registrations: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/regular_expressions_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/regular_expressions_client_capabilities.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def engine: () -> String
+
+        %a{pure}
+        def version: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/related_full_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/related_full_document_diagnostic_report.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def result_id: () -> String?
+
+        %a{pure}
+        def items: () -> Array[untyped]
+
+        %a{pure}
+        def related_documents: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/related_unchanged_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/related_unchanged_document_diagnostic_report.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def result_id: () -> String
+
+        %a{pure}
+        def related_documents: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/relative_pattern.rbs
+++ b/sig/language_server/protocol/interface/relative_pattern.rbs
@@ -12,6 +12,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def base_uri: () -> untyped
+
+        %a{pure}
+        def pattern: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/rename_client_capabilities.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def prepare_support: () -> bool?
+
+        %a{pure}
+        def prepare_support_default_behavior: () -> untyped
+
+        %a{pure}
+        def honors_change_annotations: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_file.rbs
+++ b/sig/language_server/protocol/interface/rename_file.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def old_uri: () -> String
+
+        %a{pure}
+        def new_uri: () -> String
+
+        %a{pure}
+        def options: () -> untyped
+
+        %a{pure}
+        def annotation_id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_file_options.rbs
+++ b/sig/language_server/protocol/interface/rename_file_options.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def overwrite: () -> bool?
+
+        %a{pure}
+        def ignore_if_exists: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_files_params.rbs
+++ b/sig/language_server/protocol/interface/rename_files_params.rbs
@@ -11,6 +11,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def files: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_options.rbs
+++ b/sig/language_server/protocol/interface/rename_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def prepare_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_params.rbs
+++ b/sig/language_server/protocol/interface/rename_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def new_name: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/rename_registration_options.rbs
+++ b/sig/language_server/protocol/interface/rename_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def prepare_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/request_message.rbs
+++ b/sig/language_server/protocol/interface/request_message.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def jsonrpc: () -> String
+
+        %a{pure}
+        def id: () -> untyped
+
+        %a{pure}
+        def method: () -> String
+
+        %a{pure}
+        def params: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/response_error.rbs
+++ b/sig/language_server/protocol/interface/response_error.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def code: () -> Integer
+
+        %a{pure}
+        def message: () -> String
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/response_message.rbs
+++ b/sig/language_server/protocol/interface/response_message.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def jsonrpc: () -> String
+
+        %a{pure}
+        def id: () -> untyped
+
+        %a{pure}
+        def result: () -> untyped
+
+        %a{pure}
+        def error: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/save_options.rbs
+++ b/sig/language_server/protocol/interface/save_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def include_text: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/selection_range.rbs
+++ b/sig/language_server/protocol/interface/selection_range.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def parent: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/selection_range_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/selection_range_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/selection_range_options.rbs
+++ b/sig/language_server/protocol/interface/selection_range_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/selection_range_params.rbs
+++ b/sig/language_server/protocol/interface/selection_range_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def positions: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/selection_range_registration_options.rbs
+++ b/sig/language_server/protocol/interface/selection_range_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def result_id: () -> String?
+
+        %a{pure}
+        def data: () -> Array[Integer]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_client_capabilities.rbs
@@ -7,6 +7,33 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def requests: () -> untyped
+
+        %a{pure}
+        def token_types: () -> Array[String]
+
+        %a{pure}
+        def token_modifiers: () -> Array[String]
+
+        %a{pure}
+        def formats: () -> Array[untyped]
+
+        %a{pure}
+        def overlapping_token_support: () -> bool?
+
+        %a{pure}
+        def multiline_token_support: () -> bool?
+
+        %a{pure}
+        def server_cancel_support: () -> bool?
+
+        %a{pure}
+        def augments_syntax_tokens: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_delta.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_delta.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def result_id: () -> String?
+
+        %a{pure}
+        def edits: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_delta_params.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_delta_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def previous_result_id: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_delta_partial_result.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_delta_partial_result.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def edits: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_edit.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_edit.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def start: () -> Integer
+
+        %a{pure}
+        def delete_count: () -> Integer
+
+        %a{pure}
+        def data: () -> Array[Integer]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_legend.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_legend.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def token_types: () -> Array[String]
+
+        %a{pure}
+        def token_modifiers: () -> Array[String]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_options.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_options.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def legend: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def full: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_params.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_partial_result.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_partial_result.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def data: () -> Array[Integer]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_range_params.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_range_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_registration_options.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_registration_options.rbs
@@ -7,6 +7,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def legend: () -> untyped
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def full: () -> untyped
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/semantic_tokens_workspace_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/semantic_tokens_workspace_client_capabilities.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def refresh_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/server_capabilities.rbs
+++ b/sig/language_server/protocol/interface/server_capabilities.rbs
@@ -7,6 +7,111 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def position_encoding: () -> String?
+
+        %a{pure}
+        def text_document_sync: () -> untyped
+
+        %a{pure}
+        def notebook_document_sync: () -> untyped
+
+        %a{pure}
+        def completion_provider: () -> untyped
+
+        %a{pure}
+        def hover_provider: () -> untyped
+
+        %a{pure}
+        def signature_help_provider: () -> untyped
+
+        %a{pure}
+        def declaration_provider: () -> untyped
+
+        %a{pure}
+        def definition_provider: () -> untyped
+
+        %a{pure}
+        def type_definition_provider: () -> untyped
+
+        %a{pure}
+        def implementation_provider: () -> untyped
+
+        %a{pure}
+        def references_provider: () -> untyped
+
+        %a{pure}
+        def document_highlight_provider: () -> untyped
+
+        %a{pure}
+        def document_symbol_provider: () -> untyped
+
+        %a{pure}
+        def code_action_provider: () -> untyped
+
+        %a{pure}
+        def code_lens_provider: () -> untyped
+
+        %a{pure}
+        def document_link_provider: () -> untyped
+
+        %a{pure}
+        def color_provider: () -> untyped
+
+        %a{pure}
+        def document_formatting_provider: () -> untyped
+
+        %a{pure}
+        def document_range_formatting_provider: () -> untyped
+
+        %a{pure}
+        def document_on_type_formatting_provider: () -> untyped
+
+        %a{pure}
+        def rename_provider: () -> untyped
+
+        %a{pure}
+        def folding_range_provider: () -> untyped
+
+        %a{pure}
+        def execute_command_provider: () -> untyped
+
+        %a{pure}
+        def selection_range_provider: () -> untyped
+
+        %a{pure}
+        def linked_editing_range_provider: () -> untyped
+
+        %a{pure}
+        def call_hierarchy_provider: () -> untyped
+
+        %a{pure}
+        def semantic_tokens_provider: () -> untyped
+
+        %a{pure}
+        def moniker_provider: () -> untyped
+
+        %a{pure}
+        def type_hierarchy_provider: () -> untyped
+
+        %a{pure}
+        def inline_value_provider: () -> untyped
+
+        %a{pure}
+        def inlay_hint_provider: () -> untyped
+
+        %a{pure}
+        def diagnostic_provider: () -> untyped
+
+        %a{pure}
+        def workspace_symbol_provider: () -> untyped
+
+        %a{pure}
+        def workspace: () -> untyped
+
+        %a{pure}
+        def experimental: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/set_trace_params.rbs
+++ b/sig/language_server/protocol/interface/set_trace_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def value: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/show_document_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/show_document_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def support: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/show_document_params.rbs
+++ b/sig/language_server/protocol/interface/show_document_params.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def external: () -> bool?
+
+        %a{pure}
+        def take_focus: () -> bool?
+
+        %a{pure}
+        def selection: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/show_document_result.rbs
+++ b/sig/language_server/protocol/interface/show_document_result.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def success: () -> bool
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/show_message_params.rbs
+++ b/sig/language_server/protocol/interface/show_message_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def type: () -> untyped
+
+        %a{pure}
+        def message: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/show_message_request_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/show_message_request_client_capabilities.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def message_action_item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/show_message_request_params.rbs
+++ b/sig/language_server/protocol/interface/show_message_request_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def type: () -> untyped
+
+        %a{pure}
+        def message: () -> String
+
+        %a{pure}
+        def actions: () -> Array[untyped]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_help.rbs
+++ b/sig/language_server/protocol/interface/signature_help.rbs
@@ -12,6 +12,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def signatures: () -> Array[untyped]
+
+        %a{pure}
+        def active_signature: () -> Integer?
+
+        %a{pure}
+        def active_parameter: () -> Integer?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_help_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/signature_help_client_capabilities.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def signature_information: () -> untyped
+
+        %a{pure}
+        def context_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_help_context.rbs
+++ b/sig/language_server/protocol/interface/signature_help_context.rbs
@@ -11,6 +11,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def trigger_kind: () -> untyped
+
+        %a{pure}
+        def trigger_character: () -> String?
+
+        %a{pure}
+        def is_retrigger: () -> bool
+
+        %a{pure}
+        def active_signature_help: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_help_options.rbs
+++ b/sig/language_server/protocol/interface/signature_help_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def trigger_characters: () -> Array[String]?
+
+        %a{pure}
+        def retrigger_characters: () -> Array[String]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_help_params.rbs
+++ b/sig/language_server/protocol/interface/signature_help_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def context: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_help_registration_options.rbs
+++ b/sig/language_server/protocol/interface/signature_help_registration_options.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def trigger_characters: () -> Array[String]?
+
+        %a{pure}
+        def retrigger_characters: () -> Array[String]?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/signature_information.rbs
+++ b/sig/language_server/protocol/interface/signature_information.rbs
@@ -12,6 +12,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def label: () -> String
+
+        %a{pure}
+        def documentation: () -> untyped
+
+        %a{pure}
+        def parameters: () -> Array[untyped]?
+
+        %a{pure}
+        def active_parameter: () -> Integer?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/static_registration_options.rbs
+++ b/sig/language_server/protocol/interface/static_registration_options.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/symbol_information.rbs
+++ b/sig/language_server/protocol/interface/symbol_information.rbs
@@ -11,6 +11,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def name: () -> String
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def deprecated: () -> bool?
+
+        %a{pure}
+        def location: () -> untyped
+
+        %a{pure}
+        def container_name: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_change_registration_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_change_registration_options.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def sync_kind: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/text_document_client_capabilities.rbs
@@ -10,6 +10,96 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def synchronization: () -> untyped
+
+        %a{pure}
+        def completion: () -> untyped
+
+        %a{pure}
+        def hover: () -> untyped
+
+        %a{pure}
+        def signature_help: () -> untyped
+
+        %a{pure}
+        def declaration: () -> untyped
+
+        %a{pure}
+        def definition: () -> untyped
+
+        %a{pure}
+        def type_definition: () -> untyped
+
+        %a{pure}
+        def implementation: () -> untyped
+
+        %a{pure}
+        def references: () -> untyped
+
+        %a{pure}
+        def document_highlight: () -> untyped
+
+        %a{pure}
+        def document_symbol: () -> untyped
+
+        %a{pure}
+        def code_action: () -> untyped
+
+        %a{pure}
+        def code_lens: () -> untyped
+
+        %a{pure}
+        def document_link: () -> untyped
+
+        %a{pure}
+        def color_provider: () -> untyped
+
+        %a{pure}
+        def formatting: () -> untyped
+
+        %a{pure}
+        def range_formatting: () -> untyped
+
+        %a{pure}
+        def on_type_formatting: () -> untyped
+
+        %a{pure}
+        def rename: () -> untyped
+
+        %a{pure}
+        def publish_diagnostics: () -> untyped
+
+        %a{pure}
+        def folding_range: () -> untyped
+
+        %a{pure}
+        def selection_range: () -> untyped
+
+        %a{pure}
+        def linked_editing_range: () -> untyped
+
+        %a{pure}
+        def call_hierarchy: () -> untyped
+
+        %a{pure}
+        def semantic_tokens: () -> untyped
+
+        %a{pure}
+        def moniker: () -> untyped
+
+        %a{pure}
+        def type_hierarchy: () -> untyped
+
+        %a{pure}
+        def inline_value: () -> untyped
+
+        %a{pure}
+        def inlay_hint: () -> untyped
+
+        %a{pure}
+        def diagnostic: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_content_change_event.rbs
+++ b/sig/language_server/protocol/interface/text_document_content_change_event.rbs
@@ -11,6 +11,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def range_length: () -> Integer?
+
+        %a{pure}
+        def text: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_edit.rbs
+++ b/sig/language_server/protocol/interface/text_document_edit.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def edits: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/text_document_identifier.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_item.rbs
+++ b/sig/language_server/protocol/interface/text_document_item.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def language_id: () -> String
+
+        %a{pure}
+        def version: () -> Integer
+
+        %a{pure}
+        def text: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_position_params.rbs
+++ b/sig/language_server/protocol/interface/text_document_position_params.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_registration_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_registration_options.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_save_registration_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_save_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def include_text: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_sync_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/text_document_sync_client_capabilities.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def will_save: () -> bool?
+
+        %a{pure}
+        def will_save_wait_until: () -> bool?
+
+        %a{pure}
+        def did_save: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_document_sync_options.rbs
+++ b/sig/language_server/protocol/interface/text_document_sync_options.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def open_close: () -> bool?
+
+        %a{pure}
+        def change: () -> untyped
+
+        %a{pure}
+        def will_save: () -> bool?
+
+        %a{pure}
+        def will_save_wait_until: () -> bool?
+
+        %a{pure}
+        def save: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/text_edit.rbs
+++ b/sig/language_server/protocol/interface/text_edit.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def new_text: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_definition_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/type_definition_client_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def link_support: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_definition_options.rbs
+++ b/sig/language_server/protocol/interface/type_definition_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_definition_params.rbs
+++ b/sig/language_server/protocol/interface/type_definition_params.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_definition_registration_options.rbs
+++ b/sig/language_server/protocol/interface/type_definition_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_hierarchy_item.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_item.rbs
@@ -7,6 +7,30 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def name: () -> String
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def detail: () -> String?
+
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def range: () -> untyped
+
+        %a{pure}
+        def selection_range: () -> untyped
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_hierarchy_options.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_hierarchy_prepare_params.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_prepare_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def position: () -> untyped
+
+        %a{pure}
+        def work_done_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_hierarchy_registration_options.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_registration_options.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_selector: () -> untyped
+
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def id: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_hierarchy_subtypes_params.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_subtypes_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/type_hierarchy_supertypes_params.rbs
+++ b/sig/language_server/protocol/interface/type_hierarchy_supertypes_params.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def item: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/unchanged_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/unchanged_document_diagnostic_report.rbs
@@ -11,6 +11,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def result_id: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/unregistration.rbs
+++ b/sig/language_server/protocol/interface/unregistration.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def id: () -> String
+
+        %a{pure}
+        def method: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/unregistration_params.rbs
+++ b/sig/language_server/protocol/interface/unregistration_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def unregisterations: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/versioned_notebook_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/versioned_notebook_document_identifier.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def version: () -> Integer
+
+        %a{pure}
+        def uri: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/versioned_text_document_identifier.rbs
+++ b/sig/language_server/protocol/interface/versioned_text_document_identifier.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def version: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/will_save_text_document_params.rbs
+++ b/sig/language_server/protocol/interface/will_save_text_document_params.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def text_document: () -> untyped
+
+        %a{pure}
+        def reason: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_begin.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_begin.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def title: () -> String
+
+        %a{pure}
+        def cancellable: () -> bool?
+
+        %a{pure}
+        def message: () -> String?
+
+        %a{pure}
+        def percentage: () -> Integer?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_cancel_params.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_cancel_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_create_params.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_create_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_end.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_end.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def message: () -> String?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_options.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_options.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_params.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_params.rbs
@@ -7,6 +7,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/work_done_progress_report.rbs
+++ b/sig/language_server/protocol/interface/work_done_progress_report.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def cancellable: () -> bool?
+
+        %a{pure}
+        def message: () -> String?
+
+        %a{pure}
+        def percentage: () -> Integer?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_diagnostic_params.rbs
+++ b/sig/language_server/protocol/interface/workspace_diagnostic_params.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def identifier: () -> String?
+
+        %a{pure}
+        def previous_result_ids: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/workspace_diagnostic_report.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def items: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_diagnostic_report_partial_result.rbs
+++ b/sig/language_server/protocol/interface/workspace_diagnostic_report_partial_result.rbs
@@ -10,6 +10,9 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def items: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_edit.rbs
+++ b/sig/language_server/protocol/interface/workspace_edit.rbs
@@ -7,6 +7,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def changes: () -> untyped
+
+        %a{pure}
+        def document_changes: () -> Array[untyped]?
+
+        %a{pure}
+        def change_annotations: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_edit_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/workspace_edit_client_capabilities.rbs
@@ -7,6 +7,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def document_changes: () -> bool?
+
+        %a{pure}
+        def resource_operations: () -> Array[untyped]?
+
+        %a{pure}
+        def failure_handling: () -> untyped
+
+        %a{pure}
+        def normalizes_line_endings: () -> bool?
+
+        %a{pure}
+        def change_annotation_support: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_folder.rbs
+++ b/sig/language_server/protocol/interface/workspace_folder.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def name: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_folders_change_event.rbs
+++ b/sig/language_server/protocol/interface/workspace_folders_change_event.rbs
@@ -10,6 +10,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def added: () -> Array[untyped]
+
+        %a{pure}
+        def removed: () -> Array[untyped]
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_folders_server_capabilities.rbs
+++ b/sig/language_server/protocol/interface/workspace_folders_server_capabilities.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def supported: () -> bool?
+
+        %a{pure}
+        def change_notifications: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_full_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/workspace_full_document_diagnostic_report.rbs
@@ -10,6 +10,21 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def result_id: () -> String?
+
+        %a{pure}
+        def items: () -> Array[untyped]
+
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def version: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_symbol.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol.rbs
@@ -10,6 +10,24 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def name: () -> String
+
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def tags: () -> Array[untyped]?
+
+        %a{pure}
+        def container_name: () -> String?
+
+        %a{pure}
+        def location: () -> untyped
+
+        %a{pure}
+        def data: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_symbol_client_capabilities.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_client_capabilities.rbs
@@ -7,6 +7,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def dynamic_registration: () -> bool?
+
+        %a{pure}
+        def symbol_kind: () -> untyped
+
+        %a{pure}
+        def tag_support: () -> untyped
+
+        %a{pure}
+        def resolve_support: () -> untyped
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_symbol_options.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_symbol_params.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_params.rbs
@@ -10,6 +10,15 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_token: () -> untyped
+
+        %a{pure}
+        def partial_result_token: () -> untyped
+
+        %a{pure}
+        def query: () -> String
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_symbol_registration_options.rbs
+++ b/sig/language_server/protocol/interface/workspace_symbol_registration_options.rbs
@@ -7,6 +7,12 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def work_done_progress: () -> bool?
+
+        %a{pure}
+        def resolve_provider: () -> bool?
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String

--- a/sig/language_server/protocol/interface/workspace_unchanged_document_diagnostic_report.rbs
+++ b/sig/language_server/protocol/interface/workspace_unchanged_document_diagnostic_report.rbs
@@ -10,6 +10,18 @@ module LanguageServer
         @attributes: Hash[Symbol, untyped]
         attr_reader attributes: Hash[Symbol, untyped]
 
+        %a{pure}
+        def kind: () -> untyped
+
+        %a{pure}
+        def result_id: () -> String
+
+        %a{pure}
+        def uri: () -> String
+
+        %a{pure}
+        def version: () -> Integer
+
         def to_hash: () -> Hash[Symbol, untyped]
 
         def to_json: (*untyped) -> String


### PR DESCRIPTION
This PR adds attribute method definitions to RBS signatures.

(We generate method types of each attribute by using type helpers written by https://github.com/mtsmfm/language_server-protocol-ruby/pull/104, so most return types become `untyped`.)