### PR TITLE
Load JSON in the IO writer

### DIFF
--- a/lib/language_server/protocol/transport/io/writer.rb
+++ b/lib/language_server/protocol/transport/io/writer.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module LanguageServer
   module Protocol
     module Transport


### PR DESCRIPTION
Summary

Require json from the IO writer itself so direct loading of language_server/protocol/transport/io/writer works without relying on entrypoint load order.

Reproduction

Requiring the writer directly and calling #write currently raises NameError because JSON is undefined. The focused external model fails on 3.17.0.6 and current main, then passes with this change.

Verification

- Existing suite: 6 runs, 11 assertions, zero failures
- Focused standalone writer model passes
- All Ruby syntax checks pass
- Steep passes
- Generated source remains clean
- Rebuilt gem preserves the expected package contents
- RuboCop LSP initialize/shutdown integration passes
- Rails 8.1.3.1 loads the candidate

No tests were changed. This source-only patch was identified and verified during an AI-assisted dependency audit.