### PR TITLE
Match exact Content-Length headers

### DIFF
--- a/lib/language_server/protocol/transport/io/reader.rb
+++ b/lib/language_server/protocol/transport/io/reader.rb
@@ -14,7 +14,10 @@ module LanguageServer
 
           def read(&block)
             while buffer = io.gets("\r\n\r\n")
-              content_length = buffer.match(/Content-Length: (\d+)/i)[1].to_i
+              content_length = buffer[/^Content-Length: (\d+)\r$/i, 1]
+              raise ArgumentError, "Missing or invalid Content-Length header" unless content_length
+
+              content_length = content_length.to_i
               message = io.read(content_length) or raise
               request = JSON.parse(message, symbolize_names: true)
               block.call(request)


### PR DESCRIPTION
Summary

Require Content-Length to appear as a complete header line instead of accepting the token inside another header name.

Reproduction

A frame containing X-Content-Length is currently accepted as if it supplied Content-Length. The focused external model fails on 3.17.0.6 and current main, then passes with this change by raising ArgumentError for a missing or invalid header.

Verification

- Existing suite: 6 runs, 11 assertions, zero failures
- Focused malformed-header model passes
- All Ruby syntax checks pass
- Steep passes
- Generated source remains clean
- Rebuilt gem preserves expected package contents
- RuboCop LSP initialize/shutdown integration passes
- Rails 8.1.3.1 loads the candidate

No tests were changed. This source-only patch was identified and verified during an AI-assisted dependency audit.