### PR TITLE
Reject truncated JSON-RPC message bodies

### DIFF
--- a/lib/language_server/protocol/transport/io/reader.rb
+++ b/lib/language_server/protocol/transport/io/reader.rb
@@ -15,7 +15,11 @@ module LanguageServer
           def read(&block)
             while buffer = io.gets("\r\n\r\n")
               content_length = buffer.match(/Content-Length: (\d+)/i)[1].to_i
-              message = io.read(content_length) or raise
+              message = io.read(content_length)
+              unless message && message.bytesize == content_length
+                raise EOFError, "Unexpected end of JSON-RPC message body"
+              end
+
               request = JSON.parse(message, symbolize_names: true)
               block.call(request)
             end


### PR DESCRIPTION
Summary

Verify that the body read returns exactly the byte count declared by Content-Length and raise EOFError when the stream ends early.

Reproduction

IO#read may return a shorter String at EOF. The current reader passes that partial body to JSON parsing, which produces an indirect parser error or can accept a complete shorter JSON value despite the declared frame length. The focused external model fails on 3.17.0.6 and current main, then passes with this change.

Verification

- Existing suite: 6 runs, 11 assertions, zero failures
- Focused truncated-body model passes
- All Ruby syntax checks pass
- Steep passes
- Generated source remains clean
- Rebuilt gem preserves expected package contents
- RuboCop LSP initialize/shutdown integration passes
- Rails 8.1.3.1 loads the candidate

No tests were changed. This source-only patch was identified and verified during an AI-assisted dependency audit.