### PR TITLE
Preserve false and null response results

### DIFF
--- a/lib/language_server/protocol/interface/response_message.rb
+++ b/lib/language_server/protocol/interface/response_message.rb
@@ -2,12 +2,15 @@ module LanguageServer
   module Protocol
     module Interface
       class ResponseMessage
-        def initialize(jsonrpc:, id:, result: nil, error: nil)
+        UNSPECIFIED = Object.new.freeze
+        private_constant :UNSPECIFIED
+
+        def initialize(jsonrpc:, id:, result: UNSPECIFIED, error: nil)
           @attributes = {}
 
           @attributes[:jsonrpc] = jsonrpc
           @attributes[:id] = id
-          @attributes[:result] = result if result
+          @attributes[:result] = result unless result.equal?(UNSPECIFIED)
           @attributes[:error] = error if error
 
           @attributes.freeze

--- a/scripts/generate_file.rb
+++ b/scripts/generate_file.rb
@@ -184,7 +184,8 @@ class Parser
   Interface = Struct.new(:name, :properties, :comment, keyword_init: true) do
     def params
       properties.map do |prop|
-        default = " nil" if prop.optional
+        default = " UNSPECIFIED" if prop.preserve_falsy
+        default = " nil" if prop.optional && !prop.preserve_falsy
         "#{prop.method_name}:#{default}"
       end.join(", ")
     end
@@ -194,7 +195,7 @@ class Parser
     end
   end
 
-  Property = Struct.new(:name, :type, :rbs_type, :optional, :comment, keyword_init: true) do
+  Property = Struct.new(:name, :type, :rbs_type, :optional, :comment, :preserve_falsy, keyword_init: true) do
     def local_name
       if RESERVED_WORDS.include?(method_name)
         "binding.local_variable_get(:#{method_name})"
@@ -515,7 +516,7 @@ class BaseProtocolInterfaceParser
           match[:name],
           {
             extends: extends(match[:extends]),
-            properties: properties(match[:body])
+            properties: properties(match[:body], interface_name: match[:name])
           }
         ]
       end
@@ -554,7 +555,7 @@ class BaseProtocolInterfaceParser
     raw_extends.split(",").map(&:strip).reject(&:empty?)
   end
 
-  def properties(body)
+  def properties(body, interface_name:)
     scan_matches(body, PROPERTY_PATTERN).map do |match|
       raw_type = match[:type].strip
       Parser::Property.new(
@@ -562,7 +563,8 @@ class BaseProtocolInterfaceParser
         type: protocol_type(raw_type),
         rbs_type: rbs_type(raw_type),
         optional: !!match[:optional],
-        comment: comment(clean_doc(match[:doc]&.sub(%r{\A/\*\*}, "")&.sub(%r{\*/\s*\z}, "")))
+        comment: comment(clean_doc(match[:doc]&.sub(%r{\A/\*\*}, "")&.sub(%r{\*/\s*\z}, ""))),
+        preserve_falsy: interface_name == "ResponseMessage" && match[:name] == "result"
       )
     end
   end

--- a/scripts/templates/interface.rb.erb
+++ b/scripts/templates/interface.rb.erb
@@ -7,11 +7,16 @@ module LanguageServer
       #
       <%- end -%>
       class <%= name %>
+        <%- if properties.any?(&:preserve_falsy) -%>
+        UNSPECIFIED = Object.new.freeze
+        private_constant :UNSPECIFIED
+
+        <%- end -%>
         def initialize(<%= params %>)
           @attributes = {}
 
         <%- properties.each do |prop| -%>
-          @attributes[:<%= prop.name %>] = <%= prop.local_name %><% if prop.optional %> if <%= prop.local_name %><% end %>
+          @attributes[:<%= prop.name %>] = <%= prop.local_name %><% if prop.preserve_falsy %> unless <%= prop.local_name %>.equal?(UNSPECIFIED)<% elsif prop.optional %> if <%= prop.local_name %><% end %>
         <%- end -%>
 
           @attributes.freeze

--- a/scripts/templates/interface.rbs.erb
+++ b/scripts/templates/interface.rbs.erb
@@ -7,6 +7,10 @@ module LanguageServer
       #
       <%- end -%>
       class <%= name %>
+        <%- if properties.any?(&:preserve_falsy) -%>
+        UNSPECIFIED: Object
+
+        <%- end -%>
         def initialize: (<%= rbs_constructor_signature %>) -> void
 
         @attributes: Hash[Symbol, untyped]

--- a/sig/language_server/protocol/interface/response_message.rbs
+++ b/sig/language_server/protocol/interface/response_message.rbs
@@ -2,6 +2,8 @@ module LanguageServer
   module Protocol
     module Interface
       class ResponseMessage
+        UNSPECIFIED: Object
+
         def initialize: (jsonrpc: String, id: untyped, ?result: untyped, ?error: untyped) -> void
 
         @attributes: Hash[Symbol, untyped]


### PR DESCRIPTION
Summary

Track whether result was explicitly supplied so JSON-RPC responses preserve false and null instead of replacing both with an empty object. Update the generator, templates, generated Ruby interface, and RBS together.

Reproduction

ResponseMessage.new(id: 1, result: false) and an explicit result: nil currently serialize result as an empty object because truthiness is used to choose the fallback. The focused external model fails on 3.17.0.6 and current main, then passes with this change.

Verification

- Existing suite: 6 runs, 11 assertions, zero failures
- Focused false/null response model passes
- All 326 interface classes and 37 constant modules load and exercise successfully
- Generator rerun is clean
- All Ruby syntax checks pass
- Steep passes
- Rebuilt gem preserves expected generated package contents
- RuboCop LSP initialize/shutdown integration passes
- Rails 8.1.3.1 loads the candidate

No tests were changed. This source-only patch was identified and verified during an AI-assisted dependency audit.